### PR TITLE
In generate_attribute_name(), ignore spaces. Fixes one AP214E3 error.

### DIFF
--- a/src/fedex_plus/classes.c
+++ b/src/fedex_plus/classes.c
@@ -434,9 +434,9 @@ generate_attribute_name( Variable a, char *out )
    /*  copy p to out  */
    /* DAR - fixed so that '\n's removed */
    for ( j=0, q=out; p, j<BUFSIZ; p++ ) {
-       /* copy p to out, 1 char at time.  Skip \n's, convert
+       /* copy p to out, 1 char at time.  Skip \n's and spaces, convert
        /*  '.' to '_', and convert to lowercase. */
-       if ( *p != '\n' ) {
+       if ( ( *p != '\n' ) && ( *p != ' ' ) ) {
 	   if ( *p == '.' ) {
 	       *q = '_';
 	   } else {


### PR DESCRIPTION
Fixes issue #3, the most obvious error with AP214E3. The c++ will now compile. 

There are problems reading p21 files, but those are separate issues.
