### PR TITLE
brlcad r45632 - remove all __OSTORE__ sections

### DIFF
--- a/src/clSchemas/example/SdaiEXAMPLE_SCHEMA.cc
+++ b/src/clSchemas/example/SdaiEXAMPLE_SCHEMA.cc
@@ -48,29 +48,6 @@ SdaiColor_var::SdaiColor_var (const char * n, EnumTypeDescriptor *et)
   set_value (n);
 }
 
-#ifdef __OSTORE__
-void 
-SdaiColor_var::Access_hook_in(void *object, 
-				enum os_access_reason reason, void *user_data, 
-				void *start_range, void *end_range)
-{
-    if(debug_access_hooks)
-        cout << "SdaiColor_var: virtual access function." << endl;
-    SdaiColor_var_access_hook_in(object, reason, user_data, start_range, end_range);
-}
-
-void 
-SdaiColor_var_access_hook_in(void *object, 
-	enum os_access_reason reason, void *user_data, 
-	void *start_range, void *end_range)
-{
-    SdaiColor_var *e = (SdaiColor_var *)object;
-    if(e->type == 0)
-        e->type = example_schemat_color;
-}
-
-#endif
-
 SdaiColor_var::operator Color () const {
   switch (v) {
 	case Color__green	:  return Color__green;
@@ -85,26 +62,12 @@ SdaiColor_var::operator Color () const {
   }
 }
 
-#ifdef __OSTORE__
-
-SCLP23(Enum) * 
-create_SdaiColor_var (os_database *db)
-{
-    if(db)
-        return new (db, 
-                    SdaiColor_var::get_os_typespec()) SdaiColor_var;
-    else
-        return new SdaiColor_var( "", example_schemat_color );
-}
-
-#else
 
 SCLP23(Enum) * 
 create_SdaiColor_var () 
 {
     return new SdaiColor_var( "", example_schemat_color );
 }
-#endif
 
 
 SdaiColor_vars::SdaiColor_vars( EnumTypeDescriptor *et )
@@ -116,39 +79,12 @@ SdaiColor_vars::~SdaiColor_vars()
 {
 }
 
-#ifdef __OSTORE__
-void 
-SdaiColor_vars_access_hook_in(void *object, 
-	enum os_access_reason reason, void *user_data, 
-	void *start_range, void *end_range)
-{
-    SdaiColor_vars *e = (SdaiColor_vars *)object;
-    if(e->enum_type == 0)
-        e->enum_type = example_schemat_color;
-}
-
-#endif
-
-#ifdef __OSTORE__
-
-STEPaggregate * 
-create_SdaiColor_vars (os_database *db) 
-{
-    if(db)
-        return new (db, 
-                    SdaiColor_vars::get_os_typespec()) SdaiColor_vars;
-    else
-        return new SdaiColor_vars( example_schemat_color );
-}
-
-#else
 
 STEPaggregate * 
 create_SdaiColor_vars ()
 {
     return new SdaiColor_vars( example_schemat_color );
 }
-#endif
 
 //////////  END ENUMERATION color
 
@@ -169,13 +105,8 @@ SdaiPoly_line::SdaiPoly_line( )
 
     eDesc = example_schemae_poly_line;
 
-#ifdef __OSTORE__
-    STEPattribute *a = new (os_segment::of(this), 
-			    STEPattribute::get_os_typespec()) 
-				STEPattribute(*a_0points,  &_points);
-#else
     STEPattribute *a = new STEPattribute(*a_0points,  &_points);
-#endif
+
     a -> set_null ();
     attributes.push (a);
 }
@@ -183,50 +114,6 @@ SdaiPoly_line::SdaiPoly_line (SdaiPoly_line& e )
 	{  CopyAs((SCLP23(Application_instance_ptr)) &e);	}
 SdaiPoly_line::~SdaiPoly_line () {  }
 
-#ifdef __OSTORE__
-
-void 
-SdaiPoly_line::Access_hook_in(void *object, 
-				enum os_access_reason reason, void *user_data, 
-				void *start_range, void *end_range)
-{
-    if(debug_access_hooks)
-        cout << "SdaiPoly_line: virtual access function." << endl;
-    SdaiPoly_line_access_hook_in(object, reason, user_data, start_range, end_range);
-}
-
-void 
-SdaiPoly_line_access_hook_in(void *object, 
-	enum os_access_reason reason, void *user_data, 
-	void *start_range, void *end_range)
-{
-    if(debug_access_hooks)
-        cout << "SdaiPoly_line: non-virtual access function." << endl;
-    SCLP23(Application_instance) *sent = (SCLP23(Application_instance) *)object;
-    if(debug_access_hooks)
-        cout << "STEPfile_id: " << sent->STEPfile_id << endl;
-    SdaiPoly_line *ent = (SdaiPoly_line *)sent;
-//    SdaiPoly_line *ent = (SdaiPoly_line *)object;
-    if(ent->eDesc == 0)
-        ent->eDesc = example_schemae_poly_line;
-    ent->attributes[0].aDesc = a_0points;
-}
-
-SCLP23(Application_instance_ptr) 
-create_SdaiPoly_line(os_database *db) 
-{
-    if(db)
-    {
-        SCLP23(DAObject_ptr) ap = new (db, SdaiPoly_line::get_os_typespec()) 
-                                   SdaiPoly_line;
-        return (SCLP23(Application_instance_ptr)) ap;
-//        return (SCLP23(Application_instance_ptr)) new (db, SdaiPoly_line::get_os_typespec()) 
-//                                   SdaiPoly_line;
-    }
-    else
-        return (SCLP23(Application_instance_ptr)) new SdaiPoly_line; 
-}
-#endif
 
 #ifdef __O3DB__
 void 
@@ -245,13 +132,7 @@ SdaiPoly_line::SdaiPoly_line( SCLP23(Application_instance) *se, int *addAttrs)
 
     eDesc = example_schemae_poly_line;
 
-#ifdef __OSTORE__
-    STEPattribute *a = new (os_segment::of(this), 
-			    STEPattribute::get_os_typespec()) 
-				STEPattribute(*a_0points,  &_points);
-#else
     STEPattribute *a = new STEPattribute(*a_0points,  &_points);
-#endif
     a -> set_null ();
 	/* Put attribute on this class' attributes list so the */
 	/*access functions still work. */
@@ -289,33 +170,15 @@ SdaiShape::SdaiShape( )
 
     eDesc = example_schemae_shape;
 
-#ifdef __OSTORE__
-    STEPattribute *a = new (os_segment::of(this), 
-			    STEPattribute::get_os_typespec()) 
-				STEPattribute(*a_1item_name,  &_item_name);
-#else
     STEPattribute *a = new STEPattribute(*a_1item_name,  &_item_name);
-#endif
     a -> set_null ();
     attributes.push (a);
 
-#ifdef __OSTORE__
-    a = new (os_segment::of(this), 
-			    STEPattribute::get_os_typespec()) 
-				STEPattribute(*a_2item_color,  &_item_color);
-#else
     a = new STEPattribute(*a_2item_color,  &_item_color);
-#endif
     a -> set_null ();
     attributes.push (a);
 
-#ifdef __OSTORE__
-    a = new (os_segment::of(this), 
-			    STEPattribute::get_os_typespec()) 
-				STEPattribute(*a_3number_of_sides,  &_number_of_sides);
-#else
     a = new STEPattribute(*a_3number_of_sides,  &_number_of_sides);
-#endif
     a -> set_null ();
     attributes.push (a);
 }
@@ -323,52 +186,6 @@ SdaiShape::SdaiShape (SdaiShape& e )
 	{  CopyAs((SCLP23(Application_instance_ptr)) &e);	}
 SdaiShape::~SdaiShape () {  }
 
-#ifdef __OSTORE__
-
-void 
-SdaiShape::Access_hook_in(void *object, 
-				enum os_access_reason reason, void *user_data, 
-				void *start_range, void *end_range)
-{
-    if(debug_access_hooks)
-        cout << "SdaiShape: virtual access function." << endl;
-    SdaiShape_access_hook_in(object, reason, user_data, start_range, end_range);
-}
-
-void 
-SdaiShape_access_hook_in(void *object, 
-	enum os_access_reason reason, void *user_data, 
-	void *start_range, void *end_range)
-{
-    if(debug_access_hooks)
-        cout << "SdaiShape: non-virtual access function." << endl;
-    SCLP23(Application_instance) *sent = (SCLP23(Application_instance) *)object;
-    if(debug_access_hooks)
-        cout << "STEPfile_id: " << sent->STEPfile_id << endl;
-    SdaiShape *ent = (SdaiShape *)sent;
-//    SdaiShape *ent = (SdaiShape *)object;
-    if(ent->eDesc == 0)
-        ent->eDesc = example_schemae_shape;
-    ent->attributes[0].aDesc = a_1item_name;
-    ent->attributes[1].aDesc = a_2item_color;
-    ent->attributes[2].aDesc = a_3number_of_sides;
-}
-
-SCLP23(Application_instance_ptr) 
-create_SdaiShape(os_database *db) 
-{
-    if(db)
-    {
-        SCLP23(DAObject_ptr) ap = new (db, SdaiShape::get_os_typespec()) 
-                                   SdaiShape;
-        return (SCLP23(Application_instance_ptr)) ap;
-//        return (SCLP23(Application_instance_ptr)) new (db, SdaiShape::get_os_typespec()) 
-//                                   SdaiShape;
-    }
-    else
-        return (SCLP23(Application_instance_ptr)) new SdaiShape; 
-}
-#endif
 
 #ifdef __O3DB__
 void 
@@ -389,13 +206,7 @@ SdaiShape::SdaiShape( SCLP23(Application_instance) *se, int *addAttrs)
 
     eDesc = example_schemae_shape;
 
-#ifdef __OSTORE__
-    STEPattribute *a = new (os_segment::of(this), 
-			    STEPattribute::get_os_typespec()) 
-				STEPattribute(*a_1item_name,  &_item_name);
-#else
     STEPattribute *a = new STEPattribute(*a_1item_name,  &_item_name);
-#endif
     a -> set_null ();
 	/* Put attribute on this class' attributes list so the */
 	/*access functions still work. */
@@ -405,13 +216,7 @@ SdaiShape::SdaiShape( SCLP23(Application_instance) *se, int *addAttrs)
     if(!addAttrs || addAttrs[0])
         se->attributes.push (a);
 
-#ifdef __OSTORE__
-    a = new (os_segment::of(this), 
-			    STEPattribute::get_os_typespec()) 
-				STEPattribute(*a_2item_color,  &_item_color);
-#else
     a = new STEPattribute(*a_2item_color,  &_item_color);
-#endif
     a -> set_null ();
 	/* Put attribute on this class' attributes list so the */
 	/*access functions still work. */
@@ -421,13 +226,7 @@ SdaiShape::SdaiShape( SCLP23(Application_instance) *se, int *addAttrs)
     if(!addAttrs || addAttrs[0])
         se->attributes.push (a);
 
-#ifdef __OSTORE__
-    a = new (os_segment::of(this), 
-			    STEPattribute::get_os_typespec()) 
-				STEPattribute(*a_3number_of_sides,  &_number_of_sides);
-#else
     a = new STEPattribute(*a_3number_of_sides,  &_number_of_sides);
-#endif
     a -> set_null ();
 	/* Put attribute on this class' attributes list so the */
 	/*access functions still work. */
@@ -494,23 +293,11 @@ SdaiRectangle::SdaiRectangle( )
 
     eDesc = example_schemae_rectangle;
 
-#ifdef __OSTORE__
-    STEPattribute *a = new (os_segment::of(this), 
-			    STEPattribute::get_os_typespec()) 
-				STEPattribute(*a_4height,  &_height);
-#else
     STEPattribute *a = new STEPattribute(*a_4height,  &_height);
-#endif
     a -> set_null ();
     attributes.push (a);
 
-#ifdef __OSTORE__
-    a = new (os_segment::of(this), 
-			    STEPattribute::get_os_typespec()) 
-				STEPattribute(*a_5width,  &_width);
-#else
     a = new STEPattribute(*a_5width,  &_width);
-#endif
     a -> set_null ();
     attributes.push (a);
 }
@@ -584,13 +371,7 @@ SdaiRectangle::SdaiRectangle (SCLP23(Application_instance) *se, int *addAttrs) :
 
     eDesc = example_schemae_rectangle;
 
-#ifdef __OSTORE__
-    STEPattribute *a = new (os_segment::of(this), 
-			    STEPattribute::get_os_typespec()) 
-				STEPattribute(*a_4height,  &_height);
-#else
     STEPattribute *a = new STEPattribute(*a_4height,  &_height);
-#endif
     a -> set_null ();
 	/* Put attribute on this class' attributes list so the */
 	/*access functions still work. */
@@ -600,13 +381,7 @@ SdaiRectangle::SdaiRectangle (SCLP23(Application_instance) *se, int *addAttrs) :
     if(!addAttrs || addAttrs[0])
         se->attributes.push (a);
 
-#ifdef __OSTORE__
-    a = new (os_segment::of(this), 
-			    STEPattribute::get_os_typespec()) 
-				STEPattribute(*a_5width,  &_width);
-#else
     a = new STEPattribute(*a_5width,  &_width);
-#endif
     a -> set_null ();
 	/* Put attribute on this class' attributes list so the */
 	/*access functions still work. */
@@ -664,50 +439,6 @@ SdaiSquare::SdaiSquare (SdaiSquare& e )
 	{  CopyAs((SCLP23(Application_instance_ptr)) &e);	}
 SdaiSquare::~SdaiSquare () {  }
 
-#ifdef __OSTORE__
-
-void 
-SdaiSquare::Access_hook_in(void *object, 
-				enum os_access_reason reason, void *user_data, 
-				void *start_range, void *end_range)
-{
-    if(debug_access_hooks)
-        cout << "SdaiSquare: virtual access function." << endl;
-    SdaiSquare_access_hook_in(object, reason, user_data, start_range, end_range);
-}
-
-void 
-SdaiSquare_access_hook_in(void *object, 
-	enum os_access_reason reason, void *user_data, 
-	void *start_range, void *end_range)
-{
-    if(debug_access_hooks)
-        cout << "SdaiSquare: non-virtual access function." << endl;
-    SCLP23(Application_instance) *sent = (SCLP23(Application_instance) *)object;
-    if(debug_access_hooks)
-        cout << "STEPfile_id: " << sent->STEPfile_id << endl;
-    SdaiSquare *ent = (SdaiSquare *)sent;
-//    SdaiSquare *ent = (SdaiSquare *)object;
-    if(ent->eDesc == 0)
-        ent->eDesc = example_schemae_square;
-}
-
-SCLP23(Application_instance_ptr) 
-create_SdaiSquare(os_database *db) 
-{
-    if(db)
-    {
-        SCLP23(DAObject_ptr) ap = new (db, SdaiSquare::get_os_typespec()) 
-                                   SdaiSquare;
-        return (SCLP23(Application_instance_ptr)) ap;
-//        return (SCLP23(Application_instance_ptr)) new (db, SdaiSquare::get_os_typespec()) 
-//                                   SdaiSquare;
-    }
-    else
-        return (SCLP23(Application_instance_ptr)) new SdaiSquare; 
-}
-#endif
-
 #ifdef __O3DB__
 void 
 SdaiSquare::oodb_reInit ()
@@ -747,86 +478,21 @@ SdaiTriangle::SdaiTriangle( )
 
     eDesc = example_schemae_triangle;
 
-#ifdef __OSTORE__
-    STEPattribute *a = new (os_segment::of(this), 
-			    STEPattribute::get_os_typespec()) 
-				STEPattribute(*a_6side1_length,  &_side1_length);
-#else
     STEPattribute *a = new STEPattribute(*a_6side1_length,  &_side1_length);
-#endif
     a -> set_null ();
     attributes.push (a);
 
-#ifdef __OSTORE__
-    a = new (os_segment::of(this), 
-			    STEPattribute::get_os_typespec()) 
-				STEPattribute(*a_7side2_length,  &_side2_length);
-#else
     a = new STEPattribute(*a_7side2_length,  &_side2_length);
-#endif
     a -> set_null ();
     attributes.push (a);
 
-#ifdef __OSTORE__
-    a = new (os_segment::of(this), 
-			    STEPattribute::get_os_typespec()) 
-				STEPattribute(*a_8side3_length,  &_side3_length);
-#else
     a = new STEPattribute(*a_8side3_length,  &_side3_length);
-#endif
     a -> set_null ();
     attributes.push (a);
 }
 SdaiTriangle::SdaiTriangle (SdaiTriangle& e ) 
 	{  CopyAs((SCLP23(Application_instance_ptr)) &e);	}
 SdaiTriangle::~SdaiTriangle () {  }
-
-#ifdef __OSTORE__
-
-void 
-SdaiTriangle::Access_hook_in(void *object, 
-				enum os_access_reason reason, void *user_data, 
-				void *start_range, void *end_range)
-{
-    if(debug_access_hooks)
-        cout << "SdaiTriangle: virtual access function." << endl;
-    SdaiTriangle_access_hook_in(object, reason, user_data, start_range, end_range);
-}
-
-void 
-SdaiTriangle_access_hook_in(void *object, 
-	enum os_access_reason reason, void *user_data, 
-	void *start_range, void *end_range)
-{
-    if(debug_access_hooks)
-        cout << "SdaiTriangle: non-virtual access function." << endl;
-    SCLP23(Application_instance) *sent = (SCLP23(Application_instance) *)object;
-    if(debug_access_hooks)
-        cout << "STEPfile_id: " << sent->STEPfile_id << endl;
-    SdaiTriangle *ent = (SdaiTriangle *)sent;
-//    SdaiTriangle *ent = (SdaiTriangle *)object;
-    if(ent->eDesc == 0)
-        ent->eDesc = example_schemae_triangle;
-    ent->attributes[3].aDesc = a_6side1_length;
-    ent->attributes[4].aDesc = a_7side2_length;
-    ent->attributes[5].aDesc = a_8side3_length;
-}
-
-SCLP23(Application_instance_ptr) 
-create_SdaiTriangle(os_database *db) 
-{
-    if(db)
-    {
-        SCLP23(DAObject_ptr) ap = new (db, SdaiTriangle::get_os_typespec()) 
-                                   SdaiTriangle;
-        return (SCLP23(Application_instance_ptr)) ap;
-//        return (SCLP23(Application_instance_ptr)) new (db, SdaiTriangle::get_os_typespec()) 
-//                                   SdaiTriangle;
-    }
-    else
-        return (SCLP23(Application_instance_ptr)) new SdaiTriangle; 
-}
-#endif
 
 #ifdef __O3DB__
 void 
@@ -849,13 +515,7 @@ SdaiTriangle::SdaiTriangle (SCLP23(Application_instance) *se, int *addAttrs) : S
 
     eDesc = example_schemae_triangle;
 
-#ifdef __OSTORE__
-    STEPattribute *a = new (os_segment::of(this), 
-			    STEPattribute::get_os_typespec()) 
-				STEPattribute(*a_6side1_length,  &_side1_length);
-#else
     STEPattribute *a = new STEPattribute(*a_6side1_length,  &_side1_length);
-#endif
     a -> set_null ();
 	/* Put attribute on this class' attributes list so the */
 	/*access functions still work. */
@@ -865,13 +525,7 @@ SdaiTriangle::SdaiTriangle (SCLP23(Application_instance) *se, int *addAttrs) : S
     if(!addAttrs || addAttrs[0])
         se->attributes.push (a);
 
-#ifdef __OSTORE__
-    a = new (os_segment::of(this), 
-			    STEPattribute::get_os_typespec()) 
-				STEPattribute(*a_7side2_length,  &_side2_length);
-#else
     a = new STEPattribute(*a_7side2_length,  &_side2_length);
-#endif
     a -> set_null ();
 	/* Put attribute on this class' attributes list so the */
 	/*access functions still work. */
@@ -881,13 +535,7 @@ SdaiTriangle::SdaiTriangle (SCLP23(Application_instance) *se, int *addAttrs) : S
     if(!addAttrs || addAttrs[0])
         se->attributes.push (a);
 
-#ifdef __OSTORE__
-    a = new (os_segment::of(this), 
-			    STEPattribute::get_os_typespec()) 
-				STEPattribute(*a_8side3_length,  &_side3_length);
-#else
     a = new STEPattribute(*a_8side3_length,  &_side3_length);
-#endif
     a -> set_null ();
 	/* Put attribute on this class' attributes list so the */
 	/*access functions still work. */
@@ -955,64 +603,13 @@ SdaiCircle::SdaiCircle( )
 
     eDesc = example_schemae_circle;
 
-#ifdef __OSTORE__
-    STEPattribute *a = new (os_segment::of(this), 
-			    STEPattribute::get_os_typespec()) 
-				STEPattribute(*a_9radius,  &_radius);
-#else
     STEPattribute *a = new STEPattribute(*a_9radius,  &_radius);
-#endif
     a -> set_null ();
     attributes.push (a);
 }
 SdaiCircle::SdaiCircle (SdaiCircle& e ) 
 	{  CopyAs((SCLP23(Application_instance_ptr)) &e);	}
 SdaiCircle::~SdaiCircle () {  }
-
-#ifdef __OSTORE__
-
-void 
-SdaiCircle::Access_hook_in(void *object, 
-				enum os_access_reason reason, void *user_data, 
-				void *start_range, void *end_range)
-{
-    if(debug_access_hooks)
-        cout << "SdaiCircle: virtual access function." << endl;
-    SdaiCircle_access_hook_in(object, reason, user_data, start_range, end_range);
-}
-
-void 
-SdaiCircle_access_hook_in(void *object, 
-	enum os_access_reason reason, void *user_data, 
-	void *start_range, void *end_range)
-{
-    if(debug_access_hooks)
-        cout << "SdaiCircle: non-virtual access function." << endl;
-    SCLP23(Application_instance) *sent = (SCLP23(Application_instance) *)object;
-    if(debug_access_hooks)
-        cout << "STEPfile_id: " << sent->STEPfile_id << endl;
-    SdaiCircle *ent = (SdaiCircle *)sent;
-//    SdaiCircle *ent = (SdaiCircle *)object;
-    if(ent->eDesc == 0)
-        ent->eDesc = example_schemae_circle;
-    ent->attributes[3].aDesc = a_9radius;
-}
-
-SCLP23(Application_instance_ptr) 
-create_SdaiCircle(os_database *db) 
-{
-    if(db)
-    {
-        SCLP23(DAObject_ptr) ap = new (db, SdaiCircle::get_os_typespec()) 
-                                   SdaiCircle;
-        return (SCLP23(Application_instance_ptr)) ap;
-//        return (SCLP23(Application_instance_ptr)) new (db, SdaiCircle::get_os_typespec()) 
-//                                   SdaiCircle;
-    }
-    else
-        return (SCLP23(Application_instance_ptr)) new SdaiCircle; 
-}
-#endif
 
 #ifdef __O3DB__
 void 
@@ -1033,13 +630,7 @@ SdaiCircle::SdaiCircle (SCLP23(Application_instance) *se, int *addAttrs) : SdaiS
 
     eDesc = example_schemae_circle;
 
-#ifdef __OSTORE__
-    STEPattribute *a = new (os_segment::of(this), 
-			    STEPattribute::get_os_typespec()) 
-				STEPattribute(*a_9radius,  &_radius);
-#else
     STEPattribute *a = new STEPattribute(*a_9radius,  &_radius);
-#endif
     a -> set_null ();
 	/* Put attribute on this class' attributes list so the */
 	/*access functions still work. */
@@ -1080,23 +671,11 @@ SdaiLine::SdaiLine( )
 
     eDesc = example_schemae_line;
 
-#ifdef __OSTORE__
-    STEPattribute *a = new (os_segment::of(this), 
-			    STEPattribute::get_os_typespec()) 
-				STEPattribute(*a_10end_point_one, (SCLP23(Application_instance_ptr) *) &_end_point_one);
-#else
     STEPattribute *a = new STEPattribute(*a_10end_point_one, (SCLP23(Application_instance_ptr) *) &_end_point_one);
-#endif
     a -> set_null ();
     attributes.push (a);
 
-#ifdef __OSTORE__
-    a = new (os_segment::of(this), 
-			    STEPattribute::get_os_typespec()) 
-				STEPattribute(*a_11end_point_two, (SCLP23(Application_instance_ptr) *) &_end_point_two);
-#else
     a = new STEPattribute(*a_11end_point_two, (SCLP23(Application_instance_ptr) *) &_end_point_two);
-#endif
     a -> set_null ();
     attributes.push (a);
 }
@@ -1104,55 +683,6 @@ SdaiLine::SdaiLine (SdaiLine& e )
 	{  CopyAs((SCLP23(Application_instance_ptr)) &e);	}
 SdaiLine::~SdaiLine () {  }
 
-#ifdef __OSTORE__
-
-void 
-SdaiLine::Access_hook_in(void *object, 
-				enum os_access_reason reason, void *user_data, 
-				void *start_range, void *end_range)
-{
-    if(debug_access_hooks)
-        cout << "SdaiLine: virtual access function." << endl;
-    SdaiLine_access_hook_in(object, reason, user_data, start_range, end_range);
-}
-
-void 
-SdaiLine_access_hook_in(void *object, 
-	enum os_access_reason reason, void *user_data, 
-	void *start_range, void *end_range)
-{
-    if(debug_access_hooks)
-        cout << "SdaiLine: non-virtual access function." << endl;
-    SCLP23(Application_instance) *sent = (SCLP23(Application_instance) *)object;
-    if(debug_access_hooks)
-        cout << "STEPfile_id: " << sent->STEPfile_id << endl;
-    SdaiLine *ent = (SdaiLine *)sent;
-//    SdaiLine *ent = (SdaiLine *)object;
-    if(ent->eDesc == 0)
-        ent->eDesc = example_schemae_line;
-    ent->attributes[0].aDesc = a_10end_point_one;
-    if(ent->_end_point_one == 0) 
-        ent->_end_point_one = S_ENTITY_NULL;
-    ent->attributes[1].aDesc = a_11end_point_two;
-    if(ent->_end_point_two == 0) 
-        ent->_end_point_two = S_ENTITY_NULL;
-}
-
-SCLP23(Application_instance_ptr) 
-create_SdaiLine(os_database *db) 
-{
-    if(db)
-    {
-        SCLP23(DAObject_ptr) ap = new (db, SdaiLine::get_os_typespec()) 
-                                   SdaiLine;
-        return (SCLP23(Application_instance_ptr)) ap;
-//        return (SCLP23(Application_instance_ptr)) new (db, SdaiLine::get_os_typespec()) 
-//                                   SdaiLine;
-    }
-    else
-        return (SCLP23(Application_instance_ptr)) new SdaiLine; 
-}
-#endif
 
 #ifdef __O3DB__
 void 
@@ -1172,13 +702,7 @@ SdaiLine::SdaiLine( SCLP23(Application_instance) *se, int *addAttrs)
 
     eDesc = example_schemae_line;
 
-#ifdef __OSTORE__
-    STEPattribute *a = new (os_segment::of(this), 
-			    STEPattribute::get_os_typespec()) 
-				STEPattribute(*a_10end_point_one, (SCLP23(Application_instance_ptr) *) &_end_point_one);
-#else
     STEPattribute *a = new STEPattribute(*a_10end_point_one, (SCLP23(Application_instance_ptr) *) &_end_point_one);
-#endif
     a -> set_null ();
 	/* Put attribute on this class' attributes list so the */
 	/*access functions still work. */
@@ -1188,13 +712,7 @@ SdaiLine::SdaiLine( SCLP23(Application_instance) *se, int *addAttrs)
     if(!addAttrs || addAttrs[0])
         se->attributes.push (a);
 
-#ifdef __OSTORE__
-    a = new (os_segment::of(this), 
-			    STEPattribute::get_os_typespec()) 
-				STEPattribute(*a_11end_point_two, (SCLP23(Application_instance_ptr) *) &_end_point_two);
-#else
     a = new STEPattribute(*a_11end_point_two, (SCLP23(Application_instance_ptr) *) &_end_point_two);
-#endif
     a -> set_null ();
 	/* Put attribute on this class' attributes list so the */
 	/*access functions still work. */
@@ -1247,86 +765,21 @@ SdaiCartesian_point::SdaiCartesian_point( )
 
     eDesc = example_schemae_cartesian_point;
 
-#ifdef __OSTORE__
-    STEPattribute *a = new (os_segment::of(this), 
-			    STEPattribute::get_os_typespec()) 
-				STEPattribute(*a_12x,  &_x);
-#else
     STEPattribute *a = new STEPattribute(*a_12x,  &_x);
-#endif
     a -> set_null ();
     attributes.push (a);
 
-#ifdef __OSTORE__
-    a = new (os_segment::of(this), 
-			    STEPattribute::get_os_typespec()) 
-				STEPattribute(*a_13y,  &_y);
-#else
     a = new STEPattribute(*a_13y,  &_y);
-#endif
     a -> set_null ();
     attributes.push (a);
 
-#ifdef __OSTORE__
-    a = new (os_segment::of(this), 
-			    STEPattribute::get_os_typespec()) 
-				STEPattribute(*a_14z,  &_z);
-#else
     a = new STEPattribute(*a_14z,  &_z);
-#endif
     a -> set_null ();
     attributes.push (a);
 }
 SdaiCartesian_point::SdaiCartesian_point (SdaiCartesian_point& e ) 
 	{  CopyAs((SCLP23(Application_instance_ptr)) &e);	}
 SdaiCartesian_point::~SdaiCartesian_point () {  }
-
-#ifdef __OSTORE__
-
-void 
-SdaiCartesian_point::Access_hook_in(void *object, 
-				enum os_access_reason reason, void *user_data, 
-				void *start_range, void *end_range)
-{
-    if(debug_access_hooks)
-        cout << "SdaiCartesian_point: virtual access function." << endl;
-    SdaiCartesian_point_access_hook_in(object, reason, user_data, start_range, end_range);
-}
-
-void 
-SdaiCartesian_point_access_hook_in(void *object, 
-	enum os_access_reason reason, void *user_data, 
-	void *start_range, void *end_range)
-{
-    if(debug_access_hooks)
-        cout << "SdaiCartesian_point: non-virtual access function." << endl;
-    SCLP23(Application_instance) *sent = (SCLP23(Application_instance) *)object;
-    if(debug_access_hooks)
-        cout << "STEPfile_id: " << sent->STEPfile_id << endl;
-    SdaiCartesian_point *ent = (SdaiCartesian_point *)sent;
-//    SdaiCartesian_point *ent = (SdaiCartesian_point *)object;
-    if(ent->eDesc == 0)
-        ent->eDesc = example_schemae_cartesian_point;
-    ent->attributes[0].aDesc = a_12x;
-    ent->attributes[1].aDesc = a_13y;
-    ent->attributes[2].aDesc = a_14z;
-}
-
-SCLP23(Application_instance_ptr) 
-create_SdaiCartesian_point(os_database *db) 
-{
-    if(db)
-    {
-        SCLP23(DAObject_ptr) ap = new (db, SdaiCartesian_point::get_os_typespec()) 
-                                   SdaiCartesian_point;
-        return (SCLP23(Application_instance_ptr)) ap;
-//        return (SCLP23(Application_instance_ptr)) new (db, SdaiCartesian_point::get_os_typespec()) 
-//                                   SdaiCartesian_point;
-    }
-    else
-        return (SCLP23(Application_instance_ptr)) new SdaiCartesian_point; 
-}
-#endif
 
 #ifdef __O3DB__
 void 
@@ -1347,13 +800,7 @@ SdaiCartesian_point::SdaiCartesian_point( SCLP23(Application_instance) *se, int 
 
     eDesc = example_schemae_cartesian_point;
 
-#ifdef __OSTORE__
-    STEPattribute *a = new (os_segment::of(this), 
-			    STEPattribute::get_os_typespec()) 
-				STEPattribute(*a_12x,  &_x);
-#else
     STEPattribute *a = new STEPattribute(*a_12x,  &_x);
-#endif
     a -> set_null ();
 	/* Put attribute on this class' attributes list so the */
 	/*access functions still work. */
@@ -1363,13 +810,7 @@ SdaiCartesian_point::SdaiCartesian_point( SCLP23(Application_instance) *se, int 
     if(!addAttrs || addAttrs[0])
         se->attributes.push (a);
 
-#ifdef __OSTORE__
-    a = new (os_segment::of(this), 
-			    STEPattribute::get_os_typespec()) 
-				STEPattribute(*a_13y,  &_y);
-#else
     a = new STEPattribute(*a_13y,  &_y);
-#endif
     a -> set_null ();
 	/* Put attribute on this class' attributes list so the */
 	/*access functions still work. */
@@ -1379,13 +820,7 @@ SdaiCartesian_point::SdaiCartesian_point( SCLP23(Application_instance) *se, int 
     if(!addAttrs || addAttrs[0])
         se->attributes.push (a);
 
-#ifdef __OSTORE__
-    a = new (os_segment::of(this), 
-			    STEPattribute::get_os_typespec()) 
-				STEPattribute(*a_14z,  &_z);
-#else
     a = new STEPattribute(*a_14z,  &_z);
-#endif
     a -> set_null ();
 	/* Put attribute on this class' attributes list so the */
 	/*access functions still work. */
@@ -1438,124 +873,42 @@ SdaiCartesian_point::z_ (const SdaiPoint x)
 /////////	 END_ENTITY cartesian_point
 
 
-#ifdef __OSTORE__
-SCLP23(Model_contents_ptr) create_SdaiModel_contents_example_schema(os_database *db)
-{
-    if(db)
-	return (SCLP23(Model_contents_ptr)) new (db, SdaiModel_contents_example_schema::get_os_typespec()) 
-			SdaiModel_contents_example_schema(db);
-    else{
-	return (SCLP23(Model_contents_ptr)) new SdaiModel_contents_example_schema(0);
-    }
-}
-#else
-
 SCLP23(Model_contents_ptr) create_SdaiModel_contents_example_schema()
 { return new SdaiModel_contents_example_schema ; }
-#endif
 
-
-#ifdef __OSTORE__
-SdaiModel_contents_example_schema::SdaiModel_contents_example_schema(os_database *db)
-#else
 SdaiModel_contents_example_schema::SdaiModel_contents_example_schema()
-#endif
 {
     SCLP23(Entity_extent_ptr) eep = (SCLP23(Entity_extent_ptr))0;
 
-#ifdef __OSTORE__
-    if(db)
-        eep = new (db, 
-              SCLP23(Entity_extent)::get_os_typespec()) SCLP23(Entity_extent);
-    else
-        eep = new SCLP23(Entity_extent);
-#else
-        eep = new SCLP23(Entity_extent);
-#endif
+    eep = new SCLP23(Entity_extent);
     eep->definition_(example_schemae_poly_line);
     _folders.Append(eep);
 
-#ifdef __OSTORE__
-    if(db)
-        eep = new (db, 
-              SCLP23(Entity_extent)::get_os_typespec()) SCLP23(Entity_extent);
-    else
         eep = new SCLP23(Entity_extent);
-#else
-        eep = new SCLP23(Entity_extent);
-#endif
     eep->definition_(example_schemae_shape);
     _folders.Append(eep);
 
-#ifdef __OSTORE__
-    if(db)
-        eep = new (db, 
-              SCLP23(Entity_extent)::get_os_typespec()) SCLP23(Entity_extent);
-    else
         eep = new SCLP23(Entity_extent);
-#else
-        eep = new SCLP23(Entity_extent);
-#endif
     eep->definition_(example_schemae_rectangle);
     _folders.Append(eep);
 
-#ifdef __OSTORE__
-    if(db)
-        eep = new (db, 
-              SCLP23(Entity_extent)::get_os_typespec()) SCLP23(Entity_extent);
-    else
         eep = new SCLP23(Entity_extent);
-#else
-        eep = new SCLP23(Entity_extent);
-#endif
     eep->definition_(example_schemae_square);
     _folders.Append(eep);
 
-#ifdef __OSTORE__
-    if(db)
-        eep = new (db, 
-              SCLP23(Entity_extent)::get_os_typespec()) SCLP23(Entity_extent);
-    else
         eep = new SCLP23(Entity_extent);
-#else
-        eep = new SCLP23(Entity_extent);
-#endif
     eep->definition_(example_schemae_triangle);
     _folders.Append(eep);
 
-#ifdef __OSTORE__
-    if(db)
-        eep = new (db, 
-              SCLP23(Entity_extent)::get_os_typespec()) SCLP23(Entity_extent);
-    else
         eep = new SCLP23(Entity_extent);
-#else
-        eep = new SCLP23(Entity_extent);
-#endif
     eep->definition_(example_schemae_circle);
     _folders.Append(eep);
 
-#ifdef __OSTORE__
-    if(db)
-        eep = new (db, 
-              SCLP23(Entity_extent)::get_os_typespec()) SCLP23(Entity_extent);
-    else
         eep = new SCLP23(Entity_extent);
-#else
-        eep = new SCLP23(Entity_extent);
-#endif
     eep->definition_(example_schemae_line);
     _folders.Append(eep);
 
-#ifdef __OSTORE__
-    if(db)
-        eep = new (db, 
-              SCLP23(Entity_extent)::get_os_typespec()) SCLP23(Entity_extent);
-    else
         eep = new SCLP23(Entity_extent);
-#else
-        eep = new SCLP23(Entity_extent);
-#endif
     eep->definition_(example_schemae_cartesian_point);
     _folders.Append(eep);
 

--- a/src/clSchemas/example/SdaiEXAMPLE_SCHEMA.h
+++ b/src/clSchemas/example/SdaiEXAMPLE_SCHEMA.h
@@ -5,10 +5,6 @@
 // regenerate it.
 /* $Id$  */
 
-#ifdef __OSTORE__
-#include <ostore/ostore.hh>    // Required to access ObjectStore Class Library
-#endif
-
 #ifdef __O3DB__
 #include <OpenOODB.h>
 #endif
@@ -41,10 +37,6 @@ enum Color {
 
 class SdaiColor_var  :  public SCLP23(Enum)  {
 
-#ifdef __OSTORE__
-  friend void SdaiColor_var_access_hook_in(void *, 
-	enum os_access_reason, void *, void *, void *);
-#endif
   protected:
 	EnumTypeDescriptor *type;
 
@@ -62,34 +54,14 @@ class SdaiColor_var  :  public SCLP23(Enum)  {
 	inline virtual int no_elements () const  {  return 8;  }
 	virtual const char * element_at (int n) const;
 
-#ifdef __OSTORE__
-	static os_typespec* get_os_typespec();
-	virtual void Access_hook_in(void *object, 
-		enum os_access_reason reason, void *user_data, 
-		void *start_range, void *end_range);
-#endif
 };
 
 typedef SdaiColor_var * SdaiColor_var_ptr;
 
-#ifdef __OSTORE__
-void SdaiColor_var_access_hook_in(void *object, 
-	enum os_access_reason reason, void *user_data, 
-	void *start_range, void *end_range);
-#endif
-
-#if __OSTORE__
-  SCLP23(Enum) * create_SdaiColor_var (os_database *db);
-#else
   SCLP23(Enum) * create_SdaiColor_var ();
-#endif
 
 class SdaiColor_vars  :  public EnumAggregate  {
 
-#ifdef __OSTORE__
-  friend void SdaiColor_vars_access_hook_in(void *, 
-	enum os_access_reason, void *, void *, void *);
-#endif
   protected:
     EnumTypeDescriptor *enum_type;
 
@@ -99,24 +71,11 @@ class SdaiColor_vars  :  public EnumAggregate  {
     virtual SingleLinkNode * NewNode()
 	{ return new EnumNode (new SdaiColor_var( "", enum_type )); }
 
-#ifdef __OSTORE__
-    static os_typespec* get_os_typespec();
-#endif
 };
-
-#ifdef __OSTORE__
-void SdaiColor_vars_access_hook_in(void *object, 
-	enum os_access_reason reason, void *user_data, 
-	void *start_range, void *end_range);
-#endif
 
 typedef SdaiColor_vars * SdaiColor_vars_ptr;
 
-#if __OSTORE__
-  STEPaggregate * create_SdaiColor_vars (os_database *db);
-#else
   STEPaggregate * create_SdaiColor_vars ();
-#endif
 
 //////////  END ENUMERATION color
 
@@ -133,10 +92,6 @@ extern AttrDescriptor *a_0points;
 
 class SdaiPoly_line  :    public SCLP23(Application_instance) {
 
-#ifdef __OSTORE__
-  friend void SdaiPoly_line_access_hook_in(void *, 
-	enum os_access_reason, void *, void *, void *);
-#endif
   protected:
 	EntityAggregate _points ;	  //  of  line
 
@@ -156,26 +111,9 @@ class SdaiPoly_line  :    public SCLP23(Application_instance) {
 	void points_ (const EntityAggregate_ptr x);
 
 
-#ifdef __OSTORE__
-	static os_typespec* get_os_typespec();
-	virtual void Access_hook_in(void *object, 
-		enum os_access_reason reason, void *user_data, 
-		void *start_range, void *end_range);
-#endif
-
 };
 
-#ifdef __OSTORE__
-void SdaiPoly_line_access_hook_in(void *object, 
-	enum os_access_reason reason, void *user_data, 
-	void *start_range, void *end_range);
-#endif
-
-#ifdef __OSTORE__
-SCLP23(Application_instance_ptr) 
-create_SdaiPoly_line(os_database *db);
-
-#elif __O3DB__
+#ifdef __O3DB__
 inline SCLP23(Application_instance_ptr) 
 create_SdaiPoly_line () {  return (SCLP23(Application_instance_ptr)) new SdaiPoly_line ;  }
 #else
@@ -194,10 +132,6 @@ extern AttrDescriptor *a_3number_of_sides;
 
 class SdaiShape  :    public SCLP23(Application_instance) {
 
-#ifdef __OSTORE__
-  friend void SdaiShape_access_hook_in(void *, 
-	enum os_access_reason, void *, void *, void *);
-#endif
   protected:
 	SCLP23(String) _item_name ;
 	SdaiColor_var _item_color ;    //  OPTIONAL
@@ -224,26 +158,9 @@ class SdaiShape  :    public SCLP23(Application_instance) {
 	void number_of_sides_ (const SCLP23(Integer) x);
 
 
-#ifdef __OSTORE__
-	static os_typespec* get_os_typespec();
-	virtual void Access_hook_in(void *object, 
-		enum os_access_reason reason, void *user_data, 
-		void *start_range, void *end_range);
-#endif
-
 };
 
-#ifdef __OSTORE__
-void SdaiShape_access_hook_in(void *object, 
-	enum os_access_reason reason, void *user_data, 
-	void *start_range, void *end_range);
-#endif
-
-#ifdef __OSTORE__
-SCLP23(Application_instance_ptr) 
-create_SdaiShape(os_database *db);
-
-#elif __O3DB__
+#ifdef __O3DB__
 inline SCLP23(Application_instance_ptr) 
 create_SdaiShape () {  return (SCLP23(Application_instance_ptr)) new SdaiShape ;  }
 #else
@@ -261,10 +178,6 @@ extern AttrDescriptor *a_5width;
 
 class SdaiRectangle  :    public SdaiShape  {
  
-#ifdef __OSTORE__
-  friend void SdaiRectangle_access_hook_in(void *, 
-	enum os_access_reason, void *, void *, void *);
-#endif
   protected:
 	SCLP23(Real) _height ;
 	SCLP23(Real) _width ;
@@ -289,26 +202,9 @@ class SdaiRectangle  :    public SdaiShape  {
 	/* The first parent's access functions are */
 	/* above or covered by inherited functions. */
 
-#ifdef __OSTORE__
-	static os_typespec* get_os_typespec();
-	virtual void Access_hook_in(void *object, 
-		enum os_access_reason reason, void *user_data, 
-		void *start_range, void *end_range);
-#endif
-
 };
 
-#ifdef __OSTORE__
-void SdaiRectangle_access_hook_in(void *object, 
-	enum os_access_reason reason, void *user_data, 
-	void *start_range, void *end_range);
-#endif
-
-#ifdef __OSTORE__
-SCLP23(Application_instance_ptr) 
-create_SdaiRectangle(os_database *db);
-
-#elif __O3DB__
+#ifdef __O3DB__
 inline SCLP23(Application_instance_ptr) 
 create_SdaiRectangle () {  return (SCLP23(Application_instance_ptr)) new SdaiRectangle ;  }
 #else
@@ -324,10 +220,6 @@ create_SdaiRectangle () {  return  new SdaiRectangle ;  }
 
 class SdaiSquare  :    public SdaiRectangle  {
  
-#ifdef __OSTORE__
-  friend void SdaiSquare_access_hook_in(void *, 
-	enum os_access_reason, void *, void *, void *);
-#endif
   protected:
   public:  
 
@@ -344,26 +236,9 @@ class SdaiSquare  :    public SdaiRectangle  {
 	/* The first parent's access functions are */
 	/* above or covered by inherited functions. */
 
-#ifdef __OSTORE__
-	static os_typespec* get_os_typespec();
-	virtual void Access_hook_in(void *object, 
-		enum os_access_reason reason, void *user_data, 
-		void *start_range, void *end_range);
-#endif
-
 };
 
-#ifdef __OSTORE__
-void SdaiSquare_access_hook_in(void *object, 
-	enum os_access_reason reason, void *user_data, 
-	void *start_range, void *end_range);
-#endif
-
-#ifdef __OSTORE__
-SCLP23(Application_instance_ptr) 
-create_SdaiSquare(os_database *db);
-
-#elif __O3DB__
+#ifdef __O3DB__
 inline SCLP23(Application_instance_ptr) 
 create_SdaiSquare () {  return (SCLP23(Application_instance_ptr)) new SdaiSquare ;  }
 #else
@@ -382,10 +257,6 @@ extern AttrDescriptor *a_8side3_length;
 
 class SdaiTriangle  :    public SdaiShape  {
  
-#ifdef __OSTORE__
-  friend void SdaiTriangle_access_hook_in(void *, 
-	enum os_access_reason, void *, void *, void *);
-#endif
   protected:
 	SCLP23(Real) _side1_length ;
 	SCLP23(Real) _side2_length ;
@@ -414,26 +285,9 @@ class SdaiTriangle  :    public SdaiShape  {
 	/* The first parent's access functions are */
 	/* above or covered by inherited functions. */
 
-#ifdef __OSTORE__
-	static os_typespec* get_os_typespec();
-	virtual void Access_hook_in(void *object, 
-		enum os_access_reason reason, void *user_data, 
-		void *start_range, void *end_range);
-#endif
-
 };
 
-#ifdef __OSTORE__
-void SdaiTriangle_access_hook_in(void *object, 
-	enum os_access_reason reason, void *user_data, 
-	void *start_range, void *end_range);
-#endif
-
-#ifdef __OSTORE__
-SCLP23(Application_instance_ptr) 
-create_SdaiTriangle(os_database *db);
-
-#elif __O3DB__
+#ifdef __O3DB__
 inline SCLP23(Application_instance_ptr) 
 create_SdaiTriangle () {  return (SCLP23(Application_instance_ptr)) new SdaiTriangle ;  }
 #else
@@ -450,10 +304,6 @@ extern AttrDescriptor *a_9radius;
 
 class SdaiCircle  :    public SdaiShape  {
  
-#ifdef __OSTORE__
-  friend void SdaiCircle_access_hook_in(void *, 
-	enum os_access_reason, void *, void *, void *);
-#endif
   protected:
 	SCLP23(Real) _radius ;
   public:  
@@ -474,26 +324,9 @@ class SdaiCircle  :    public SdaiShape  {
 	/* The first parent's access functions are */
 	/* above or covered by inherited functions. */
 
-#ifdef __OSTORE__
-	static os_typespec* get_os_typespec();
-	virtual void Access_hook_in(void *object, 
-		enum os_access_reason reason, void *user_data, 
-		void *start_range, void *end_range);
-#endif
-
 };
 
-#ifdef __OSTORE__
-void SdaiCircle_access_hook_in(void *object, 
-	enum os_access_reason reason, void *user_data, 
-	void *start_range, void *end_range);
-#endif
-
-#ifdef __OSTORE__
-SCLP23(Application_instance_ptr) 
-create_SdaiCircle(os_database *db);
-
-#elif __O3DB__
+#ifdef __O3DB__
 inline SCLP23(Application_instance_ptr) 
 create_SdaiCircle () {  return (SCLP23(Application_instance_ptr)) new SdaiCircle ;  }
 #else
@@ -511,10 +344,6 @@ extern AttrDescriptor *a_11end_point_two;
 
 class SdaiLine  :    public SCLP23(Application_instance) {
 
-#ifdef __OSTORE__
-  friend void SdaiLine_access_hook_in(void *, 
-	enum os_access_reason, void *, void *, void *);
-#endif
   protected:
 	SCLP23(Application_instance_ptr) _end_point_one ;
 	SCLP23(Application_instance_ptr) _end_point_two ;
@@ -537,26 +366,9 @@ class SdaiLine  :    public SCLP23(Application_instance) {
 	void end_point_two_ (const SdaiCartesian_point_ptr x);
 
 
-#ifdef __OSTORE__
-	static os_typespec* get_os_typespec();
-	virtual void Access_hook_in(void *object, 
-		enum os_access_reason reason, void *user_data, 
-		void *start_range, void *end_range);
-#endif
-
 };
 
-#ifdef __OSTORE__
-void SdaiLine_access_hook_in(void *object, 
-	enum os_access_reason reason, void *user_data, 
-	void *start_range, void *end_range);
-#endif
-
-#ifdef __OSTORE__
-SCLP23(Application_instance_ptr) 
-create_SdaiLine(os_database *db);
-
-#elif __O3DB__
+#ifdef __O3DB__
 inline SCLP23(Application_instance_ptr) 
 create_SdaiLine () {  return (SCLP23(Application_instance_ptr)) new SdaiLine ;  }
 #else
@@ -575,10 +387,6 @@ extern AttrDescriptor *a_14z;
 
 class SdaiCartesian_point  :    public SCLP23(Application_instance) {
 
-#ifdef __OSTORE__
-  friend void SdaiCartesian_point_access_hook_in(void *, 
-	enum os_access_reason, void *, void *, void *);
-#endif
   protected:
 	SCLP23(Real) _x ;
 	SCLP23(Real) _y ;
@@ -605,26 +413,9 @@ class SdaiCartesian_point  :    public SCLP23(Application_instance) {
 	void z_ (const SdaiPoint x);
 
 
-#ifdef __OSTORE__
-	static os_typespec* get_os_typespec();
-	virtual void Access_hook_in(void *object, 
-		enum os_access_reason reason, void *user_data, 
-		void *start_range, void *end_range);
-#endif
-
 };
 
-#ifdef __OSTORE__
-void SdaiCartesian_point_access_hook_in(void *object, 
-	enum os_access_reason reason, void *user_data, 
-	void *start_range, void *end_range);
-#endif
-
-#ifdef __OSTORE__
-SCLP23(Application_instance_ptr) 
-create_SdaiCartesian_point(os_database *db);
-
-#elif __O3DB__
+#ifdef __O3DB__
 inline SCLP23(Application_instance_ptr) 
 create_SdaiCartesian_point () {  return (SCLP23(Application_instance_ptr)) new SdaiCartesian_point ;  }
 #else
@@ -641,11 +432,7 @@ class SdaiModel_contents_example_schema : public SCLP23(Model_contents) {
 
   public:
 
-#ifdef __OSTORE__
-    SdaiModel_contents_example_schema(os_database *db=0);
-#else
     SdaiModel_contents_example_schema();
-#endif
 
     SdaiPoly_line__set_var SdaiPoly_line_get_extents();
 
@@ -663,20 +450,12 @@ class SdaiModel_contents_example_schema : public SCLP23(Model_contents) {
 
     SdaiCartesian_point__set_var SdaiCartesian_point_get_extents();
 
-#ifdef __OSTORE__
-	static os_typespec* get_os_typespec();
-#endif
-
 };
 
 
 typedef SdaiModel_contents_example_schema * SdaiModel_contents_example_schema_ptr;
 typedef SdaiModel_contents_example_schema_ptr SdaiModel_contents_example_schema_var;
 
-#ifdef __OSTORE__
-SCLP23(Model_contents_ptr) create_SdaiModel_contents_example_schema(os_database *db);
-#else
 SCLP23(Model_contents_ptr) create_SdaiModel_contents_example_schema();
-#endif
 
 #endif

--- a/src/clSchemas/example/schema.h
+++ b/src/clSchemas/example/schema.h
@@ -8,10 +8,6 @@
 #include <sys/time.h>
 #endif
 
-#ifdef __OSTORE__
-#include <ostore/ostore.hh>    // Required to access ObjectStore Class Library
-#endif
-
 #ifdef __O3DB__
 #include <OpenOODB.h>
 #endif
@@ -34,11 +30,6 @@ extern void SchemaInit (Registry &);
 extern void InitSchemasAndEnts (Registry &);
 #include <SdaiEXAMPLE_SCHEMA.h> 
 extern void SdaiEXAMPLE_SCHEMAInit (Registry & r);
-
-#ifdef __OSTORE__
-#include <osdb_SdaiEXAMPLE_SCHEMA.h> 
-#endif
-
 
 #include <complexSupport.h>
 ComplexCollect *gencomplex();

--- a/src/cldai/StrUtil.cc
+++ b/src/cldai/StrUtil.cc
@@ -14,11 +14,6 @@
 #include <time.h>
 
 
-#ifdef __OSTORE__
-#include <ostore/ostore.hh>    // Required to access ObjectStore Class Library
-#include <ostore/coll.hh>
-#endif
-
 #include "StrUtil.hh"
 //#include "imppackages.hh"
 #include "ErrorRpt.hh"
@@ -58,62 +53,6 @@ char * strDup(char *destStr, const char *srcStr)
 
   return destStr;
 }
-
-#ifdef __OSTORE__
-char * strDup(char * destStr, const char * srcStr, os_segment * segment) 
-{
-  if (destStr != NULL)
-    {
-      delete [] destStr;
-
-      destStr = NULL;
-    }
-
-  if (srcStr != NULL)
-   {
-     destStr = new (segment, os_typespec::get_char(),
-                        strlen(srcStr)+1) char[strlen(srcStr) + 1];
-
-     if (destStr != NULL)
-       {
-         strcpy(destStr, srcStr);
-       }
-     else
-       {
-         reportServerError(serverNoMemoryError);
-       }
-   }
-
-  return destStr;
-}
-
-char * strDup(char * destStr, const char * srcStr, os_database * database) 
-{
-  if (destStr != NULL)
-    {
-      delete [] destStr;
-
-      destStr = NULL;
-    }
-
-  if (srcStr != NULL)
-   {
-     destStr = new (database, os_typespec::get_char(),
-                        strlen(srcStr)+1) char[strlen(srcStr) + 1];
-
-     if (destStr != NULL)
-       {
-         strcpy(destStr, srcStr);
-       }
-     else
-       {
-         reportServerError(serverNoMemoryError);
-       }
-   }
-
-  return destStr;
-}
-#endif __OSTORE__
 
 //
 //  Free the memory allocated to a string

--- a/src/cldai/StrUtil.hh
+++ b/src/cldai/StrUtil.hh
@@ -22,11 +22,6 @@
 //
 char * strDup(char *destStr, const char *srcStr);
 
-#ifdef __OSTORE__
-char * strDup(char *destStr, const char *srcStr, os_segment *);
-char * strDup(char *destStr, const char *srcStr, os_database *);
-#endif    // __OSTORE__
-
 //
 //   Free the memory allocated for the given string
 //

--- a/src/cldai/imptypes.hh
+++ b/src/cldai/imptypes.hh
@@ -85,11 +85,6 @@ typedef SCLP23_NAME(Application_instance__set_ptr)
 				SCLP23_NAME(Application_instance__set_var);
 
 /*
-#ifdef __OSTORE__
-// set is defined - DAS
-   typedef os_List<SCLP23_NAME(Application_instance_ptr)> 
-                                SCLP23_NAME(Application_instance__list);
-#endif
    typedef SCLP23_NAME(Application_instance__list) * 
                                 SCLP23_NAME(Application_instance__list_var);
 */

--- a/src/cldai/sdaiDaObject.cc
+++ b/src/cldai/sdaiDaObject.cc
@@ -2,10 +2,6 @@
 #include <memory.h>
 #include <math.h>
 
-#ifdef __OSTORE__
-#include <ostore/ostore.hh>    // Required to access ObjectStore Class Library
-#endif
-
 #include <sdai.h>
 
 // to help ObjectCenter
@@ -16,15 +12,6 @@ void * memmove(void *__s1, const void *__s2, size_t __n);
 }
 #endif
 
-#ifdef __OSTORE__
-void force_vfts (void*){
-  force_vfts(new os_Array<int>);
-  force_vfts(new os_Bag<int>);
-  force_vfts(new os_Collection<int>);
-  force_vfts(new os_List<int>);
-  force_vfts(new os_Set<int>);
-}
-#endif
 
 SCLP23(PID)::SCLP23_NAME(PID)()
 {
@@ -58,19 +45,6 @@ SCLP23(DAObject)::~SCLP23_NAME(DAObject)()
 {
 }
 
-#ifdef __OSTORE__
-void 
-SCLP23(DAObject)::Access_hook_in(void *object, 
-	enum os_access_reason reason, void *user_data, 
-	void *start_range, void *end_range)
-{
-    cout << "****WARNING: virtual DAObject::Access_hook_in() called" << endl;
-    SCLP23(DAObject_ptr) ent = (SCLP23(DAObject_ptr))object;
-/*
-    ent->Access_hook_in(object, reason, user_data, start_range, end_range);
-*/
-}
-#endif
 
 #ifdef PART26
 //SCLP26(Application_instance_ptr) 
@@ -96,19 +70,6 @@ SCLP23(DAObject_SDAI)::~SCLP23_NAME(DAObject_SDAI)()
 {
 }
 
-#ifdef __OSTORE__
-void 
-SCLP23(DAObject_SDAI)::Access_hook_in(void *object, 
-	enum os_access_reason reason, void *user_data, 
-	void *start_range, void *end_range)
-{
-    cout << "****WARNING: virtual DAObject_SDAI::Access_hook_in() called" << endl;
-    SCLP23(DAObject_SDAI_ptr) ent = (SCLP23(DAObject_SDAI_ptr))object;
-/*
-    ent->Access_hook_in(object, reason, user_data, start_range, end_range);
-*/
-}
-#endif
 
 #ifdef PART26
 //SCLP26(Application_instance_ptr) 
@@ -149,33 +110,19 @@ SCLP23(DAObject_SDAI)::create_TIE()
 /*****************************************************************************/
 
 SCLP23(DAObject__set)::SCLP23_NAME(DAObject__set) (int defaultSize)
-#ifdef __OSTORE__
-// : _rep(os_Collection<DAObject_ptr>::create(os_database::of(this)) ), 
- : _rep(os_List<SCLP23(DAObject_ptr)>::create(os_database::of(this)) ), 
-   _cursor(_rep),
-   _first(BTrue)
-{
-//    _rep = os_Set<DAObject_ptr>::create(os_database::of(this));
-}
-#else
 {
     _bufsize = defaultSize;
     _buf = new SCLP23(DAObject_ptr)[_bufsize];
     _count = 0;
 }
-#endif
 
 SCLP23(DAObject__set)::~SCLP23_NAME(DAObject__set) () 
 {
-#ifndef __OSTORE__
     delete _buf;
-#endif
 }
 
 void SCLP23(DAObject__set)::Check (int index) {
 
-#ifdef __OSTORE__
-#else
     SCLP23(DAObject_ptr)* newbuf;
 
     if (index >= _bufsize) {
@@ -185,15 +132,11 @@ void SCLP23(DAObject__set)::Check (int index) {
         delete _buf;
         _buf = newbuf;
     }
-#endif
 }
 
 void 
 SCLP23(DAObject__set)::Insert (SCLP23(DAObject_ptr) v, int index) {
 
-#ifdef __OSTORE__
-    _rep.insert_before( (SCLP23(DAObject_ptr)) v, index);
-#else
     SCLP23(DAObject_ptr)* spot;
     index = (index < 0) ? _count : index;
 
@@ -208,14 +151,10 @@ SCLP23(DAObject__set)::Insert (SCLP23(DAObject_ptr) v, int index) {
     }
     *spot = v;
     ++_count;
-#endif
 }
 
 void SCLP23(DAObject__set)::Append (SCLP23(DAObject_ptr) v) {
 
-#ifdef __OSTORE__
-    _rep.insert_last( (SCLP23(DAObject_ptr)) v);
-#else
     int index = _count;
     SCLP23(DAObject_ptr)* spot;
 
@@ -230,23 +169,17 @@ void SCLP23(DAObject__set)::Append (SCLP23(DAObject_ptr) v) {
     }
     *spot = v;
     ++_count;
-#endif
 }
 
 void SCLP23(DAObject__set)::Remove (int index) {
 
-#ifdef __OSTORE__
-    _rep.remove_at( index );
-#else
     if (0 <= index && index < _count) {
         --_count;
         SCLP23(DAObject_ptr)* spot = &_buf[index];
         memmove(spot, spot+1, (_count - index)*sizeof(SCLP23(DAObject_ptr)));
     }
-#endif
 }
 
-#ifndef __OSTORE__
 int SCLP23(DAObject__set)::Index (SCLP23(DAObject_ptr) v) {
 
     for (int i = 0; i < _count; ++i) {
@@ -256,19 +189,13 @@ int SCLP23(DAObject__set)::Index (SCLP23(DAObject_ptr) v) {
     }
     return -1;
 }
-#endif
 
 SCLP23(DAObject_ptr) 
 SCLP23(DAObject__set)::retrieve(int index)
 {
-#ifdef __OSTORE__
-    return _rep.retrieve(index);
-#else
     return operator[](index);
-#endif
 }
 
-#ifndef __OSTORE__
 SCLP23(DAObject_ptr)& SCLP23(DAObject__set)::operator[] (int index) {
 
     Check(index);
@@ -276,54 +203,21 @@ SCLP23(DAObject_ptr)& SCLP23(DAObject__set)::operator[] (int index) {
     _count = ( (_count > index+1) ? _count : (index+1) );
     return _buf[index];
 }
-#endif
 
 int 
 SCLP23(DAObject__set)::Count()
 {
-#ifdef __OSTORE__
-    return _rep.cardinality();
-#else
     return _count; 
-#endif
 }
 
 int 
 SCLP23(DAObject__set)::is_empty()
 {
-#ifdef __OSTORE__
-    return _rep.empty();
-#else
     return _count; 
-#endif
 }
 
-#ifndef __OSTORE__
 void 
 SCLP23(DAObject__set)::Clear()
 {
     _count = 0; 
 }
-#endif
-
-#ifdef __OSTORE__
-
-SCLP23(DAObject_ptr) 
-SCLP23(DAObject__set)::first()
-{
-    return _cursor.first();
-}
-
-SCLP23(DAObject_ptr) 
-SCLP23(DAObject__set)::next()
-{
-    return _cursor.next();
-}
-
-SCLP23(Integer) 
-SCLP23(DAObject__set)::more()
-{
-    return _cursor.more();
-}
-
-#endif

--- a/src/cldai/sdaiDaObject.h
+++ b/src/cldai/sdaiDaObject.h
@@ -79,10 +79,6 @@ class SCLP23_NAME(PID) : public SCLP23_NAME(sdaiObject)
 	{ return CORBA::string_dupl(_pidstring); }
 #endif
 
-#ifdef __OSTORE__
-    static os_typespec* get_os_typespec();
-#endif
-
 };
 
 #ifdef PART26
@@ -149,10 +145,6 @@ class SCLP23_NAME(PID_DA): public SCLP23_NAME(PID)
 	{ return CORBA::string_dupl(_oid); }
 #endif
 
-#ifdef __OSTORE__
-    static os_typespec* get_os_typespec();
-#endif
-
 };
 
 #ifdef PART26
@@ -195,10 +187,6 @@ class SCLP23_NAME(PID_SDAI) : public SCLP23_NAME(PID)
 
     virtual char * Modelid (CORBA::Environment &IT_env=CORBA::IT_chooseDefaultEnv ()) throw (CORBA::SystemException)
 	{ return CORBA::string_dupl(_modelid); }
-#endif
-
-#ifdef __OSTORE__
-    static os_typespec* get_os_typespec();
 #endif
 
 };
@@ -356,13 +344,6 @@ class SCLP23_NAME(DAObject) : public SCLP23_NAME(sdaiObject)
 #else
         virtual void dado_free (CORBA::Environment &IT_env=CORBA::IT_chooseDefaultEnv ()) throw (CORBA::SystemException)
 	{ }
-#endif
-
-#ifdef __OSTORE__
-    static os_typespec* get_os_typespec();
-    virtual void Access_hook_in(void *object, 
-	enum os_access_reason reason, void *user_data, 
-	void *start_range, void *end_range);
 #endif
 
 };
@@ -595,13 +576,6 @@ class SCLP23_NAME(DAObject_SDAI) : public SCLP23_NAME(DAObject) {
        Origin: Convenience function
      */
 
-#ifdef __OSTORE__
-    static os_typespec* get_os_typespec();
-    virtual void Access_hook_in(void *object, 
-	enum os_access_reason reason, void *user_data, 
-	void *start_range, void *end_range);
-#endif
-
 };
 
 typedef SCLP23_NAME(DAObject_SDAI)* SCLP23_NAME(DAObject_SDAI_ptr);
@@ -609,38 +583,22 @@ typedef SCLP23_NAME(DAObject_SDAI_ptr) SCLP23_NAME(DAObject_SDAI_var);
 
 class SCLP23_NAME(DAObject__set) {
 public:
-#ifdef __OSTORE__
-    os_Collection<SCLP23_NAME(DAObject_ptr)> &_rep;
-    os_Cursor<SCLP23_NAME(DAObject_ptr)> _cursor;
-    Boolean _first;
-#endif
-
     SCLP23_NAME(DAObject__set)(int = 16);
     ~SCLP23_NAME(DAObject__set)();
 
     SCLP23_NAME(DAObject_ptr) retrieve(int index);
     int is_empty();
 
-#ifndef __OSTORE__
     SCLP23_NAME(DAObject_ptr)& operator[](int index);
-#endif
 
     void Insert(SCLP23_NAME(DAObject_ptr), int index);
     void Append(SCLP23_NAME(DAObject_ptr));
     void Remove(int index);
-#ifndef __OSTORE__
+
     int Index(SCLP23_NAME(DAObject_ptr));
 
     void Clear();
-#endif
     int Count();
-
-#ifdef __OSTORE__
-// cursor stuff
-    SCLP23_NAME(DAObject_ptr) first();
-    SCLP23_NAME(DAObject_ptr) next();
-    SCLP23_NAME(Integer) more();
-#endif
 
 private:
     void Check(int index);
@@ -651,9 +609,6 @@ private:
 
   public:
 
-#ifdef __OSTORE__
-    static os_typespec* get_os_typespec();
-#endif
 };
 
 typedef SCLP23_NAME(DAObject__set)* SCLP23_NAME(DAObject__set_ptr);

--- a/src/cldai/sdaiEntity_extent.cc
+++ b/src/cldai/sdaiEntity_extent.cc
@@ -51,12 +51,7 @@ SCLP23(Entity_extent)::definition_(const Entity_ptr& ep)
 void 
 SCLP23(Entity_extent)::definition_name_(const SCLP23(Entity_name)& en)
 {
-#ifdef __OSTORE__
-  _definition_name = new (os_database::of(this), os_typespec::get_char(), 
-		     strlen(en)+1) char[strlen(en)+1];
-#else
   _definition_name = new char[strlen(en)+1];
-#endif
   strncpy (_definition_name, en, strlen(en)+1);
 }
 
@@ -126,12 +121,10 @@ SCLP23(Entity_extent)::AddInstance(const SCLP23(DAObject_ptr)& appInst)
 */
 
 
-#ifndef __OSTORE__
 void 
 SCLP23(Entity_extent)::RemoveInstance(const SCLP23(DAObject_ptr)& appInst)
 {
     _instances.Remove( _instances.Index(appInst) );
 }
-#endif
 
 /////////	 END_ENTITY SCLP23(Entity_extent) 

--- a/src/cldai/sdaiEntity_extent.h
+++ b/src/cldai/sdaiEntity_extent.h
@@ -95,9 +95,7 @@ friend class SCLP23_NAME(Model_contents);
      */
 
     // this is no longer in Part 23
-#ifndef __OSTORE__
     void RemoveInstance(const SCLP23_NAME(DAObject_ptr)& appInst);
-#endif
 
     /*
        7.3.3.1.2  RemoveInstance
@@ -114,10 +112,6 @@ friend class SCLP23_NAME(Model_contents);
 
        Origin: Convenience function
        */
-
-#ifdef __OSTORE__
-    static os_typespec* get_os_typespec();
-#endif
 
 };
 

--- a/src/cldai/sdaiEntity_extent_set.cc
+++ b/src/cldai/sdaiEntity_extent_set.cc
@@ -44,33 +44,19 @@ void * memmove(void *__s1, const void *__s2, size_t __n);
 /*****************************************************************************/
 
 SCLP23(Entity_extent__set)::SCLP23_NAME(Entity_extent__set) (int defaultSize)
-#ifdef __OSTORE__
-// : _rep(os_Collection<Entity_extent_ptr>::create(os_database::of(this)) ), 
- : _rep(os_List<SCLP23(Entity_extent_ptr)>::create(os_database::of(this)) ), 
-   _cursor(_rep),
-   _first(BTrue)
-{
-//    _rep = os_Set<Entity_extent_ptr>::create(os_database::of(this));
-}
-#else
 {
     _bufsize = defaultSize;
     _buf = new SCLP23(Entity_extent_ptr)[_bufsize];
     _count = 0;
 }
-#endif
 
 SCLP23(Entity_extent__set)::~SCLP23_NAME(Entity_extent__set) () 
 {
-#ifndef __OSTORE__
     delete _buf;
-#endif
 }
 
 void SCLP23(Entity_extent__set)::Check (int index) {
 
-#ifdef __OSTORE__
-#else
     SCLP23(Entity_extent_ptr)* newbuf;
 
     if (index >= _bufsize) {
@@ -80,15 +66,11 @@ void SCLP23(Entity_extent__set)::Check (int index) {
         delete _buf;
         _buf = newbuf;
     }
-#endif
 }
 
 void 
 SCLP23(Entity_extent__set)::Insert (SCLP23(Entity_extent_ptr) v, int index) {
 
-#ifdef __OSTORE__
-    _rep.insert_before( (SCLP23(Entity_extent_ptr)) v, index);
-#else
     SCLP23(Entity_extent_ptr)* spot;
     index = (index < 0) ? _count : index;
 
@@ -103,14 +85,10 @@ SCLP23(Entity_extent__set)::Insert (SCLP23(Entity_extent_ptr) v, int index) {
     }
     *spot = v;
     ++_count;
-#endif
 }
 
 void SCLP23(Entity_extent__set)::Append (SCLP23(Entity_extent_ptr) v) {
 
-#ifdef __OSTORE__
-    _rep.insert_last( (SCLP23(Entity_extent_ptr)) v);
-#else
     int index = _count;
     SCLP23(Entity_extent_ptr)* spot;
 
@@ -125,23 +103,17 @@ void SCLP23(Entity_extent__set)::Append (SCLP23(Entity_extent_ptr) v) {
     }
     *spot = v;
     ++_count;
-#endif
 }
 
 void SCLP23(Entity_extent__set)::Remove (int index) {
 
-#ifdef __OSTORE__
-    _rep.remove_at( index );
-#else
     if (0 <= index && index < _count) {
         --_count;
         SCLP23(Entity_extent_ptr)* spot = &_buf[index];
         memmove(spot, spot+1, (_count - index)*sizeof(SCLP23(Entity_extent_ptr)));
     }
-#endif
 }
 
-#ifndef __OSTORE__
 int SCLP23(Entity_extent__set)::Index (SCLP23(Entity_extent_ptr) v) {
 
     for (int i = 0; i < _count; ++i) {
@@ -151,76 +123,37 @@ int SCLP23(Entity_extent__set)::Index (SCLP23(Entity_extent_ptr) v) {
     }
     return -1;
 }
-#endif
 
 SCLP23(Entity_extent_ptr) 
 SCLP23(Entity_extent__set)::retrieve(int index)
 {
-#ifdef __OSTORE__
-    return _rep.retrieve(index);
-#else
     return operator[](index);
-#endif
 }
 
-#ifndef __OSTORE__
 SCLP23(Entity_extent_ptr)& SCLP23(Entity_extent__set)::operator[] (int index) {
     Check(index);
 //    _count = max(_count, index+1);
     _count = ( (_count > index+1) ? _count : (index+1) );
     return _buf[index];
 }
-#endif
 
 int 
 SCLP23(Entity_extent__set)::Count()
 {
-#ifdef __OSTORE__
-    return _rep.cardinality();
-#else
     return _count; 
-#endif
 }
 
 int 
 SCLP23(Entity_extent__set)::is_empty()
 {
-#ifdef __OSTORE__
-    return _rep.empty();
-#else
     return _count; 
-#endif
 }
 
-#ifndef __OSTORE__
 void 
 SCLP23(Entity_extent__set)::Clear()
 {
     _count = 0; 
 }
-#endif
-
-#ifdef __OSTORE__
-
-SCLP23(Entity_extent_ptr) 
-SCLP23(Entity_extent__set)::first()
-{
-    return _cursor.first();
-}
-
-SCLP23(Entity_extent_ptr) 
-SCLP23(Entity_extent__set)::next()
-{
-    return _cursor.next();
-}
-
-SCLP23(Integer) 
-SCLP23(Entity_extent__set)::more()
-{
-    return _cursor.more();
-}
-
-#endif
 
 /*****************************************************************************/
 

--- a/src/cldai/sdaiEntity_extent_set.h
+++ b/src/cldai/sdaiEntity_extent_set.h
@@ -37,11 +37,6 @@
 
 class SCLP23_NAME(Entity_extent__set) {
 public:
-#ifdef __OSTORE__
-    os_Collection<SCLP23_NAME(Entity_extent_ptr)> &_rep;
-    os_Cursor<SCLP23_NAME(Entity_extent_ptr)> _cursor;
-    Boolean _first;
-#endif
 
     SCLP23_NAME(Entity_extent__set)(int = 16);
     ~SCLP23_NAME(Entity_extent__set)();
@@ -49,25 +44,15 @@ public:
     SCLP23_NAME(Entity_extent_ptr) retrieve(int index);
     int is_empty();
 
-#ifndef __OSTORE__
     SCLP23_NAME(Entity_extent_ptr)& operator[](int index);
-#endif
+
     void Insert(SCLP23_NAME(Entity_extent_ptr), int index);
     void Append(SCLP23_NAME(Entity_extent_ptr));
     void Remove(int index);
-#ifndef __OSTORE__
     int Index(SCLP23_NAME(Entity_extent_ptr));
 
     void Clear();
-#endif
     int Count();
-
-#ifdef __OSTORE__
-// cursor stuff
-    SCLP23_NAME(Entity_extent_ptr) first();
-    SCLP23_NAME(Entity_extent_ptr) next();
-    SCLP23_NAME(Integer) more();
-#endif
 
 private:
     void Check(int index);
@@ -76,11 +61,6 @@ private:
     int _bufsize;
     int _count;
 
-  public:
-
-#ifdef __OSTORE__
-    static os_typespec* get_os_typespec();
-#endif
 };
 
 typedef SCLP23_NAME(Entity_extent__set)* SCLP23_NAME(Entity_extent__set_ptr);

--- a/src/cldai/sdaiModel_contents.cc
+++ b/src/cldai/sdaiModel_contents.cc
@@ -97,13 +97,11 @@ SCLP23(Model_contents)::AddInstance(const SCLP23(DAObject_SDAI_ptr)& appInst)
     _instances.contents_()->Append(appInst);
 }
 
-#ifndef __OSTORE__
 void 
 SCLP23(Model_contents)::RemoveInstance(SCLP23(DAObject_SDAI_ptr)& appInst)
 {
     _instances.contents_()->Remove(_instances.contents_()->Index(appInst));
 }
-#endif
 
 
 #ifdef SDAI_CPP_LATE_BINDING

--- a/src/cldai/sdaiModel_contents.h
+++ b/src/cldai/sdaiModel_contents.h
@@ -40,9 +40,6 @@ class SCLP23_NAME(Model_contents_instances) : public SCLP23_NAME(DAObject)
     const SCLP23_NAME(DAObject__set_var) contents_() const 
 	{ return (const SCLP23_NAME(DAObject__set_var)) &_instances; };
 
-#ifdef __OSTORE__
-    static os_typespec* get_os_typespec();
-#endif
 };
 
 typedef SCLP23_NAME(Model_contents_instances) *
@@ -149,9 +146,7 @@ class SCLP23_NAME(Model_contents) : public SCLP23_NAME(Session_instance) {
      */
 
     // until we find out what this should really be in the spec
-#ifndef __OSTORE__
     void RemoveInstance(SCLP23_NAME(DAObject_SDAI_ptr)& appInst);  
-#endif
 //    void RemoveInstance(Entity_instance_ptr& entityHandle);  
     //void RemoveInstance(EntityInstanceH& entityHandle);  
     /* Function
@@ -216,10 +211,6 @@ class SCLP23_NAME(Model_contents) : public SCLP23_NAME(Session_instance) {
 //    void instances (SCLP23_NAME(Model_contents_instances_ptr) x);
 //    void folders (Entity_extent__set x);
 //    void populated_folders (Entity_extent__set x);
-
-#ifdef __OSTORE__
-    static os_typespec* get_os_typespec();
-#endif
 
 };
 

--- a/src/cldai/sdaiModel_contents_list.cc
+++ b/src/cldai/sdaiModel_contents_list.cc
@@ -36,32 +36,19 @@ void * memmove(void *__s1, const void *__s2, size_t __n);
 /*****************************************************************************/
 
 SCLP23(Model_contents__list)::SCLP23_NAME(Model_contents__list) (int defaultSize)
-#ifdef __OSTORE__
- : _rep(os_List<SCLP23(Model_contents_ptr)>::create(os_database::of(this)) ), 
-   _cursor(_rep),
-   _first(BTrue)
-{
-//    _rep = os_List<Model_contents*>::create(os_database::of(this));
-#else
 {
     _bufsize = defaultSize;
     _buf = new SCLP23(Model_contents_ptr)[_bufsize];
     _count = 0;
-#endif
-
 }
 
 SCLP23(Model_contents__list)::~SCLP23_NAME(Model_contents__list) () 
 {
-#ifndef __OSTORE__
     delete _buf;
-#endif
 }
 
 void SCLP23(Model_contents__list)::Check (int index) {
 
-#ifdef __OSTORE__
-#else
     SCLP23(Model_contents_ptr)* newbuf;
 
     if (index >= _bufsize) {
@@ -71,15 +58,11 @@ void SCLP23(Model_contents__list)::Check (int index) {
         delete _buf;
         _buf = newbuf;
     }
-#endif
 }
 
 void 
 SCLP23(Model_contents__list)::Insert (SCLP23(Model_contents_ptr) v, int index) {
 
-#ifdef __OSTORE__
-    _rep.insert_before( (SCLP23(Model_contents_ptr)) v, index);
-#else
     SCLP23(Model_contents_ptr)* spot;
     index = (index < 0) ? _count : index;
 
@@ -94,14 +77,10 @@ SCLP23(Model_contents__list)::Insert (SCLP23(Model_contents_ptr) v, int index) {
     }
     *spot = v;
     ++_count;
-#endif
 }
 
 void SCLP23(Model_contents__list)::Append (SCLP23(Model_contents_ptr) v) {
 
-#ifdef __OSTORE__
-    _rep.insert_last( (SCLP23(Model_contents_ptr)) v);
-#else
     int index = _count;
     SCLP23(Model_contents_ptr)* spot;
 
@@ -116,23 +95,17 @@ void SCLP23(Model_contents__list)::Append (SCLP23(Model_contents_ptr) v) {
     }
     *spot = v;
     ++_count;
-#endif
 }
 
 void SCLP23(Model_contents__list)::Remove (int index) {
 
-#ifdef __OSTORE__
-    _rep.remove_at( index );
-#else
     if (0 <= index && index < _count) {
         --_count;
         SCLP23(Model_contents_ptr)* spot = &_buf[index];
         memmove(spot, spot+1, (_count - index)*sizeof(SCLP23(Model_contents_ptr)));
     }
-#endif
 }
 
-#ifndef __OSTORE__
 int SCLP23(Model_contents__list)::Index (SCLP23(Model_contents_ptr) v) {
 
     for (int i = 0; i < _count; ++i) {
@@ -142,19 +115,13 @@ int SCLP23(Model_contents__list)::Index (SCLP23(Model_contents_ptr) v) {
     }
     return -1;
 }
-#endif
 
 SCLP23(Model_contents_ptr) 
 SCLP23(Model_contents__list)::retrieve(int index)
 {
-#ifdef __OSTORE__
-    return _rep.retrieve(index);
-#else
     return operator[](index);
-#endif
 }
 
-#ifndef __OSTORE__
 SCLP23(Model_contents_ptr)& 
 SCLP23(Model_contents__list)::operator[] (int index) 
 {
@@ -164,54 +131,22 @@ SCLP23(Model_contents__list)::operator[] (int index)
     _count = ( (_count > index+1) ? _count : (index+1) );
     return _buf[index];
 }
-#endif
 
 int 
 SCLP23(Model_contents__list)::Count()
 {
-#ifdef __OSTORE__
-    return _rep.cardinality();
-#else
     return _count; 
-#endif
 }
 
 int 
 SCLP23(Model_contents__list)::is_empty()
 {
-#ifdef __OSTORE__
-    return _rep.empty();
-#else
     return _count; 
-#endif
 }
 
-#ifndef __OSTORE__
 void 
 SCLP23(Model_contents__list)::Clear()
 {
     _count = 0; 
 }
-#endif
 
-#ifdef __OSTORE__
-
-SCLP23(Model_contents_ptr) 
-SCLP23(Model_contents__list)::first()
-{
-    return _cursor.first();
-}
-
-SCLP23(Model_contents_ptr) 
-SCLP23(Model_contents__list)::next()
-{
-    return _cursor.next();
-}
-
-SCLP23(Integer) 
-SCLP23(Model_contents__list)::more()
-{
-    return _cursor.more();
-}
-
-#endif

--- a/src/cldai/sdaiModel_contents_list.h
+++ b/src/cldai/sdaiModel_contents_list.h
@@ -3,38 +3,21 @@
 
 class SCLP23_NAME(Model_contents__list) {
 public:
-#ifdef __OSTORE__
-    os_Collection<SCLP23_NAME(Model_contents_ptr)> &_rep;
-    os_Cursor<SCLP23_NAME(Model_contents_ptr)> _cursor;
-    Boolean _first;
-#endif
-
     SCLP23_NAME(Model_contents__list)(int = 16);
     ~SCLP23_NAME(Model_contents__list)();
 
     SCLP23_NAME(Model_contents_ptr) retrieve(int index);
     int is_empty();
 
-#ifndef __OSTORE__
     SCLP23_NAME(Model_contents_ptr)& operator[](int index);
-#endif
 
     void Insert(SCLP23_NAME(Model_contents_ptr), int index);
     void Append(SCLP23_NAME(Model_contents_ptr));
     void Remove(int index);
-#ifndef __OSTORE__
     int Index(SCLP23_NAME(Model_contents_ptr));
 
     void Clear();
-#endif
     int Count();
-
-#ifdef __OSTORE__
-// cursor stuff
-    SCLP23_NAME(Model_contents_ptr) first();
-    SCLP23_NAME(Model_contents_ptr) next();
-    SCLP23_NAME(Integer) more();
-#endif
 
 private:
     void Check(int index);
@@ -42,12 +25,6 @@ private:
     SCLP23_NAME(Model_contents_ptr)* _buf;
     int _bufsize;
     int _count;
-
-  public:
-
-#ifdef __OSTORE__
-    static os_typespec* get_os_typespec();
-#endif
 };
 
 typedef SCLP23_NAME(Model_contents__list)* 

--- a/src/cldai/sdaiObject.cc
+++ b/src/cldai/sdaiObject.cc
@@ -18,16 +18,3 @@ SCLP23(sdaiObject)::create_TIE()
 }
 #endif
 
-#ifdef __OSTORE__
-void 
-SCLP23(sdaiObject)::Access_hook_in(void *object, 
-	enum os_access_reason reason, void *user_data, 
-	void *start_range, void *end_range)
-{
-    cout << "****WARNING: virtual sdaiObject::Access_hook_in() called" << endl;
-    SCLP23(sdaiObject_ptr) ent = (SCLP23(sdaiObject_ptr))object;
-/*
-    ent->Access_hook_in(object, reason, user_data, start_range, end_range);
-*/
-}
-#endif

--- a/src/cldai/sdaiObject.h
+++ b/src/cldai/sdaiObject.h
@@ -24,12 +24,6 @@ class SCLP23_NAME(sdaiObject)
     virtual IDL_Application_instance_ptr create_TIE();
 #endif
 
-#ifdef __OSTORE__
-    static os_typespec* get_os_typespec();
-    virtual void Access_hook_in(void *object, 
-	enum os_access_reason reason, void *user_data, 
-	void *start_range, void *end_range);
-#endif
 };
 
 typedef SCLP23_NAME(sdaiObject)* SCLP23_NAME(sdaiObject_ptr);

--- a/src/cldai/sdaiSession_instance.h
+++ b/src/cldai/sdaiSession_instance.h
@@ -20,10 +20,6 @@ class SCLP23_NAME(Session_instance) : public SCLP23_NAME(sdaiObject)
 //	_narrow(SCLP23_NAME(Object_ptr) o);
 //    static SCLP23_NAME(Session_instance_ptr) _nil();
 
-#ifdef __OSTORE__
-    static os_typespec* get_os_typespec();
-#endif
-
 };
 
 typedef SCLP23_NAME(Session_instance)* SCLP23_NAME(Session_instance_ptr);

--- a/src/cleditor/STEPfile.cc
+++ b/src/cleditor/STEPfile.cc
@@ -1,7 +1,3 @@
-#ifdef __OSTORE__
-int pr_obj_errors = 0;
-#endif
-
 /*
 * NIST STEP Core Class Library
 * cleditor/STEPfile.cc
@@ -170,13 +166,6 @@ STEPfile::ReadHeader (istream& in)
 	    }
 	    else //not userDefined
 	    {
-/*
-#ifdef __OSTORE__
-		obj = _headerRegistry->ObjCreate (buf, db);
-#else
-		obj = _headerRegistry->ObjCreate (buf);
-#endif
-*/
 		obj = _headerRegistry->ObjCreate (buf);
 #ifdef __O3DB__
 		obj -> persist ();
@@ -704,25 +693,6 @@ STEPfile::ReadData1(istream& in)
 
 	}
     } // end while loop
-
-#ifdef __OSTORE__
-    if (pr_obj_errors > 4)
-    {
-	int x = 0;
-	cout << 
-	    "\nSTEPfile::ReadData1(istream& in) os_database ptrs in entities:"
-	     << endl;
-	SCLP23(Application_instance) *STEPent = 0;
-	while (x < instance_count)
-	{
-	    STEPent = instances().GetApplication_instance(x);
-	    cout << "os_database::of(STEPent): " << os_database::of(STEPent) 
-	      << endl;
-	    x++;
-	}
-	cout << endl << "***********" << endl;
-    }
-#endif
 
     if(_entsNotCreated) 
     {
@@ -1680,23 +1650,7 @@ STEPfile::CreateInstance(istream& in, ostream &out)
 	else 
 	{
 	    schemaName( schnm );
-#ifdef __OSTORE__
-	    if (pr_obj_errors > 3)
-	    {
-		cout << "STEPfile::CreateInstance() db ptr: " << db << endl;
-	    }
-
-	    obj = reg().ObjCreate(objnm.chars(), db, schnm);
-
-	    if (pr_obj_errors > 3)
-	    {
-		cout << "os_database::of(obj) in STEPfile::CreateInstance(): "
-		  << os_database::of(obj) << endl;
-		cout << "****" << endl;
-	    }
-#else
 	    obj = reg().ObjCreate(objnm.chars(), schnm);
-#endif
 	    if ( obj == ENTITY_NULL ) {
 		// This will be the case if objnm does not exist in the reg.
 		result.UserMsg( "Unknown ENTITY type" );

--- a/src/cleditor/STEPfile.h
+++ b/src/cleditor/STEPfile.h
@@ -15,10 +15,6 @@
 
 /* $Id: STEPfile.h,v 3.0.1.6 1998/02/17 18:04:30 sauderd Exp $ */ 
 
-#ifdef __OSTORE__
-#include <ostore/ostore.hh>    // Required to access ObjectStore Class Library
-#endif
-
 #ifdef __O3DB__
 #include <OpenOODB.h>
 #endif
@@ -50,14 +46,6 @@ class STEPfile
 {
   protected:
     //data members
-
-#ifdef __OSTORE__
-  public:
-    os_database *db;
-    void set_database(os_database *db_ptr) { db = db_ptr; }
-    os_database *get_database() { return db; }
-  protected:
-#endif
 
 #ifdef __O3DB__
     InstMgr *  _instances;

--- a/src/cleditor/STEPfile.inline.cc
+++ b/src/cleditor/STEPfile.inline.cc
@@ -42,9 +42,6 @@ STEPfile::STEPfile(Registry& r, InstMgr& i, const char *filename)
 #else
 : _reg(r), _instances(i), 
 #endif
-#ifdef __OSTORE__
-  db (0),
-#endif
   _headerId(0), _maxErrorCount(5000), 
   _fileName (0), _entsNotCreated(0), _entsInvalid(0), 
   _entsIncomplete(0), _entsWarning(0), 

--- a/src/cleditor/instmgr.cc
+++ b/src/cleditor/instmgr.cc
@@ -53,19 +53,8 @@ InstMgr::PrintSortedFileIds()
 InstMgr::InstMgr(int ownsInstances)
  : maxFileId(-1), _ownsInstances(ownsInstances)
 {
-
-/*
-#ifdef __OSTORE__
-    master = new (os_segment::of(this), MgrNodeArray::get_os_typespec()) 
-		MgrNodeArray();
-    sortedMaster = new (os_segment::of(this), 
-			MgrNodeArraySorted::get_os_typespec())
-		MgrNodeArraySorted();
-#else
-*/
     master = new MgrNodeArray();
     sortedMaster = new MgrNodeArraySorted();
-//#endif
 }
 
 InstMgr::~InstMgr()
@@ -249,16 +238,8 @@ MgrNode *InstMgr::Append(SCLP23(Application_instance) *se, stateEnum listState)
     // update the maxFileId if needed
     if (se->StepFileId() > MaxFileId()) maxFileId = se->StepFileId();
 
-/*
-#ifdef __OSTORE__
-    mn = new (os_segment::of(this), MgrNode::get_os_typespec()) 
-	MgrNode(se, listState);
-    cout << "Appended entity: " << flush;
-    cout << se->EntityName() << endl << flush;
-#else
-*/
     mn = new MgrNode(se, listState);
-//#endif
+
     if (debug_level > 3)
       cerr << "new MgrNode for " << mn->GetFileId() << " with state " 
 	   << mn->CurrState () << endl;

--- a/src/cleditor/instmgr.h
+++ b/src/cleditor/instmgr.h
@@ -22,11 +22,6 @@
 //	start a new undo list and delete the old undo list. 
 /////////////////////
 
-/*
-#ifdef __OSTORE__
-#include <ostore/ostore.hh>    // Required to access ObjectStore Class Library
-#endif
-*/
 
 #ifdef __O3DB__
 #include <OpenOODB.h>
@@ -114,12 +109,6 @@ public:
     void *GetSEE(MgrNode *node) { return node->SEE(); };
 
     void PrintSortedFileIds();
-
-/*
-#ifdef __OSTORE__
-    static os_typespec* get_os_typespec();
-#endif
-*/
 
     // OBSOLETE
     SCLP23(Application_instance) *GetSTEPentity(int index);

--- a/src/cleditor/mgrnode.h
+++ b/src/cleditor/mgrnode.h
@@ -14,12 +14,6 @@
 
 /* $Id: mgrnode.h,v 3.0.1.4 1997/11/05 22:11:37 sauderd DP3.1 $ */ 
 
-/*
-#ifdef __OSTORE__
-#include <ostore/ostore.hh>    // Required to access ObjectStore Class Library
-#endif
-*/
-
 #ifdef __O3DB__
 #include <OpenOODB.h>
 #endif
@@ -123,12 +117,6 @@ public:
     DisplayNode *&displayNode() { return di; }
     int ArrayIndex()		{ return arrayIndex; }
     void ArrayIndex(int index)	{ arrayIndex = index; }
-
-/*
-#ifdef __OSTORE__
-    static os_typespec* get_os_typespec();
-#endif
-*/
 
     // OBSOLETE
     SCLP23(Application_instance) *GetSTEPentity()	{ return se; }

--- a/src/cleditor/mgrnodearray.cc
+++ b/src/cleditor/mgrnodearray.cc
@@ -43,13 +43,6 @@ static int PrintFunctionTrace = 2;
 // class MgrNodeArray member functions
 //////////////////////////////////////////////////////////////////////////////
 
-//#ifdef __OSTORE__
-//MgrNodeArray::MgrNodeArray(os_database *db, int defaultSize)
-//	: GenNodeArray(db, defaultSize) 
-//{
-//}
-//#endif
-
 MgrNodeArray::MgrNodeArray(int defaultSize) 
 	: GenNodeArray(defaultSize) 
 {
@@ -137,13 +130,6 @@ int MgrNodeArray::MgrNodeIndex(int fileId)
 //////////////////////////////////////////////////////////////////////////////
 // class MgrNodeArraySorted member functions
 //////////////////////////////////////////////////////////////////////////////
-
-//#ifdef __OSTORE__
-//MgrNodeArraySorted::MgrNodeArraySorted(os_database *db, int defaultSize)
-//	: GenNodeArray(db, defaultSize) 
-//{
-//}
-//#endif
 
 MgrNodeArraySorted::MgrNodeArraySorted(int defaultSize) 
 	: GenNodeArray(defaultSize) 

--- a/src/cleditor/mgrnodearray.h
+++ b/src/cleditor/mgrnodearray.h
@@ -15,12 +15,6 @@
 
 /* $Id: mgrnodearray.h,v 3.0.1.3 1997/11/05 22:11:38 sauderd DP3.1 $ */ 
 
-/*
-#ifdef __OSTORE__
-#include <ostore/ostore.hh>    // Required to access ObjectStore Class Library
-#endif
-*/
-
 #ifdef __O3DB__
 #include <OpenOODB.h>
 #endif
@@ -49,11 +43,7 @@
 class MgrNodeArray : public GenNodeArray
 {
 public:
-//#ifdef __OSTORE__
-//    MgrNodeArray(os_database *db, int defaultSize = ARRAY_DEFAULT_SIZE);
-//#else
     MgrNodeArray(int defaultSize = ARRAY_DEFAULT_SIZE);
-//#endif
     ~MgrNodeArray();
 
 // REDEFINED functions
@@ -69,11 +59,6 @@ public:
 // ADDED functions
     virtual int MgrNodeIndex(int fileId);
     void AssignIndexAddress(int index);
-/*
-#ifdef __OSTORE__
-    static os_typespec* get_os_typespec();
-#endif
-*/
 };
 
 //////////////////////////////////////////////////////////////////////////////
@@ -86,11 +71,7 @@ public:
 
 class MgrNodeArraySorted : public GenNodeArray {
 public:
-//#ifdef __OSTORE__
-//    MgrNodeArraySorted(os_database *db, int defaultSize = ARRAY_DEFAULT_SIZE);
-//#else
     MgrNodeArraySorted(int defaultSize = ARRAY_DEFAULT_SIZE);
-//#endif
     ~MgrNodeArraySorted() { }
 
 // REDEFINED functions
@@ -110,11 +91,6 @@ public:
 // ADDED functions
     virtual int MgrNodeIndex(int fileId);
     int FindInsertPosition (const int fileId);
-/*
-#ifdef __OSTORE__
-    static os_typespec* get_os_typespec();
-#endif
-*/
 };
 
 

--- a/src/clprobe-ui/dpmenuitem.cc
+++ b/src/clprobe-ui/dpmenuitem.cc
@@ -1,8 +1,4 @@
 
-#ifdef __OSTORE__
-#include <ostore/ostore.hh>    // Required to access ObjectStore Class Library
-#endif
-
 #include <dpmenuitem.h>
 
 void 

--- a/src/clprobe-ui/headerdisp.cc
+++ b/src/clprobe-ui/headerdisp.cc
@@ -11,10 +11,6 @@
 
 /* $Id: headerdisp.cc,v 3.0.1.1 1997/11/05 23:01:05 sauderd DP3.1 $ */
 
-#ifdef __OSTORE__
-#include <ostore/ostore.hh>    // Required to access ObjectStore Class Library
-#endif
-
 #ifdef __O3DB__
 #include <OpenOODB.h>
 #endif

--- a/src/clprobe-ui/instcmdbufdisp.cc
+++ b/src/clprobe-ui/instcmdbufdisp.cc
@@ -23,10 +23,6 @@
  *    7) i(save incomplete)
  */
 
-#ifdef __OSTORE__
-#include <ostore/ostore.hh>    // Required to access ObjectStore Class Library
-#endif
-
 #ifdef __O3DB__
 #include <OpenOODB.h>
 #endif

--- a/src/clprobe-ui/probe.cc
+++ b/src/clprobe-ui/probe.cc
@@ -13,10 +13,6 @@
 
 #include <sclprefixes.h>
 
-#ifdef __OSTORE__
-#include <ostore/ostore.hh>    // Required to access ObjectStore Class Library
-#endif
-
 #ifdef __O3DB__
 #include <OpenOODB.h>
 #endif

--- a/src/clprobe-ui/probemain.cc
+++ b/src/clprobe-ui/probemain.cc
@@ -11,10 +11,6 @@
 
 /* $Id: probemain.cc,v 3.0.1.1 1997/11/05 23:01:08 sauderd DP3.1 $ */
 
-#ifdef __OSTORE__
-#include <ostore/ostore.hh>    // Required to access ObjectStore Class Library
-#endif
-
 #ifdef __O3DB__
 #include <OpenOODB.h>
 #endif

--- a/src/clprobe-ui/seinstdisp.cc
+++ b/src/clprobe-ui/seinstdisp.cc
@@ -11,10 +11,6 @@
 
 /* $Id: seinstdisp.cc,v 3.0.1.1 1997/11/05 23:01:10 sauderd DP3.1 $ */
 
-#ifdef __OSTORE__
-#include <ostore/ostore.hh>    // Required to access ObjectStore Class Library
-#endif
-
 #ifdef __O3DB__
 #include <OpenOODB.h>
 #endif

--- a/src/clprobe-ui/setypedisp.cc
+++ b/src/clprobe-ui/setypedisp.cc
@@ -11,10 +11,6 @@
 
 /* $Id: setypedisp.cc,v 3.0.1.1 1997/11/05 23:01:11 sauderd DP3.1 $ */
 
-#ifdef __OSTORE__
-#include <ostore/ostore.hh>    // Required to access ObjectStore Class Library
-#endif
-
 #ifdef __O3DB__
 #include <OpenOODB.h>
 #endif

--- a/src/clprobe-ui/stepenteditor.cc
+++ b/src/clprobe-ui/stepenteditor.cc
@@ -11,10 +11,6 @@
 
 /* $Id: stepenteditor.cc,v 3.0.1.1 1998/02/17 19:42:07 sauderd DP3.1 $ */
 
-#ifdef __OSTORE__
-#include <ostore/ostore.hh>    // Required to access ObjectStore Class Library
-#endif
-
 #ifdef __O3DB__
 #include <OpenOODB.h>
 #endif

--- a/src/clstepcore/ExpDict.cc
+++ b/src/clstepcore/ExpDict.cc
@@ -585,101 +585,45 @@ Schema::GenerateEntitiesExpress(ostream& out) const
 
 ///////////////////////////////////////////////////////////////////////////////
 
-#ifdef __OSTORE__
-EnumAggregate * create_EnumAggregate(os_database *db)
-{
-    return new (db, EnumAggregate::get_os_typespec()) EnumAggregate; 
-}
-#else
 EnumAggregate * create_EnumAggregate()
 {
     return new EnumAggregate; 
 }
-#endif
 
-#ifdef __OSTORE__
-GenericAggregate * create_GenericAggregate(os_database *db)
-{ 
-    return new (db, GenericAggregate::get_os_typespec()) GenericAggregate; 
-}
-#else
 GenericAggregate * create_GenericAggregate()
 { 
     return new GenericAggregate; 
 }
-#endif
 
-#ifdef __OSTORE__
-EntityAggregate * create_EntityAggregate(os_database *db)
-{
-    return new (db, EntityAggregate::get_os_typespec()) EntityAggregate; 
-}
-#else
 EntityAggregate * create_EntityAggregate()
 {
     return new EntityAggregate; 
 }
-#endif
 
-#ifdef __OSTORE__
-SelectAggregate * create_SelectAggregate(os_database *db)
-{
-    return new (db, SelectAggregate::get_os_typespec()) SelectAggregate;
-}
-#else
 SelectAggregate * create_SelectAggregate()
 {
     return new SelectAggregate; 
 }
-#endif
 
-#ifdef __OSTORE__
-StringAggregate * create_StringAggregate(os_database *db)
-{
-    return new (db, StringAggregate::get_os_typespec()) StringAggregate;
-}
-#else
 StringAggregate * create_StringAggregate()
 {
     return new StringAggregate; 
 }
-#endif
 
-#ifdef __OSTORE__
-BinaryAggregate * create_BinaryAggregate(os_database *db)
-{
-    return new (db, BinaryAggregate::get_os_typespec()) BinaryAggregate;
-}
-#else
 BinaryAggregate * create_BinaryAggregate()
 {
     return new BinaryAggregate; 
 }
-#endif
 
-#ifdef __OSTORE__
-RealAggregate * create_RealAggregate(os_database *db)
-{
-    return new (db, RealAggregate::get_os_typespec()) RealAggregate;
-}
-#else
 RealAggregate * create_RealAggregate()
 {
     return new RealAggregate; 
 }
-#endif
 
-#ifdef __OSTORE__
-IntAggregate * create_IntAggregate(os_database *db)
-{
-    return new (db, IntAggregate::get_os_typespec()) IntAggregate;
-}
-#else
 IntAggregate * create_IntAggregate()
 {
     return new IntAggregate; 
 }
-#endif
 
 const EntityDescriptor * 
 EntityDescItr::NextEntityDesc()
@@ -926,16 +870,6 @@ EnumTypeDescriptor::EnumTypeDescriptor (const char * nm, PrimitiveType ft,
 {
 }
 
-#ifdef __OSTORE__
-SCLP23(Enum) *
-EnumTypeDescriptor::CreateEnum(os_database *db)
-{
-    if(CreateNewEnum)
-      return CreateNewEnum(db);
-    else
-      return 0;
-}
-#else
 SCLP23(Enum) *
 EnumTypeDescriptor::CreateEnum()
 {
@@ -944,7 +878,6 @@ EnumTypeDescriptor::CreateEnum()
     else
       return 0;
 }
-#endif
 
 const char * 
 EnumTypeDescriptor::GenerateExpress (SCLstring &buf) const
@@ -2038,16 +1971,6 @@ EnumerationTypeDescriptor::EnumerationTypeDescriptor( )
 // SelectTypeDescriptor functions
 ///////////////////////////////////////////////////////////////////////////////
 
-#ifdef __OSTORE__
-SCLP23(Select) *
-SelectTypeDescriptor::CreateSelect(os_database *db)
-{
-    if(CreateNewSelect)
-      return CreateNewSelect(db);
-    else
-      return 0;
-}
-#else
 SCLP23(Select) *
 SelectTypeDescriptor::CreateSelect()
 {
@@ -2056,7 +1979,6 @@ SelectTypeDescriptor::CreateSelect()
     else
       return 0;
 }
-#endif
 
 const TypeDescriptor *
 SelectTypeDescriptor::IsA (const TypeDescriptor * other) const
@@ -2144,16 +2066,6 @@ SelectTypeDescriptor::CanBeSet (const char * other, const char *schNm) const
 // AggrTypeDescriptor functions
 ///////////////////////////////////////////////////////////////////////////////
 
-#ifdef __OSTORE__
-STEPaggregate *
-AggrTypeDescriptor::CreateAggregate(os_database *db)
-{
-    if(CreateNewAggr)
-      return CreateNewAggr(db);
-    else
-      return 0;
-}
-#else
 STEPaggregate *
 AggrTypeDescriptor::CreateAggregate()
 {
@@ -2162,7 +2074,6 @@ AggrTypeDescriptor::CreateAggregate()
     else
       return 0;
 }
-#endif
 
 
 AggrTypeDescriptor::AggrTypeDescriptor( ) : 

--- a/src/clstepcore/ExpDict.h
+++ b/src/clstepcore/ExpDict.h
@@ -14,10 +14,6 @@
 
 /* $Id: ExpDict.h,v 3.0.1.12 1998/02/17 19:19:15 sauderd DP3.1 $  */ 
 
-#ifdef __OSTORE__
-#include <ostore/ostore.hh>    // Required to access ObjectStore Class Library
-#endif
-
 #ifdef __O3DB__
 #include <OpenOODB.h>
 #endif
@@ -25,11 +21,7 @@
 #include <sdai.h>
 //class SCLP23(Application_instance);
 
-#ifdef __OSTORE__
-typedef  SCLP23(Application_instance) * (* Creator) (os_database *) ;
-#else
 typedef  SCLP23(Application_instance) * (* Creator) () ;
-#endif
 //class StringAggregate;
 
 enum AttrType_Enum {
@@ -1278,11 +1270,7 @@ class TypeDescriptor {
 	        // is USE/REFERENCE'ing us (added to altNames).
 };
 
-#ifdef __OSTORE__
-typedef  SCLP23(Enum) * (* EnumCreator) (os_database *db) ;
-#else
 typedef  SCLP23(Enum) * (* EnumCreator) () ;
-#endif
 
 class EnumTypeDescriptor  :    public TypeDescriptor  { 
   public:
@@ -1295,11 +1283,7 @@ class EnumTypeDescriptor  :    public TypeDescriptor  {
 	CreateNewEnum = f;
     }
 
-#ifdef __OSTORE__
-    SCLP23(Enum) *CreateEnum(os_database *db);
-#else
     SCLP23(Enum) *CreateEnum();
-#endif
 
     EnumTypeDescriptor ( ) { }
     EnumTypeDescriptor (const char * nm, PrimitiveType ft, 
@@ -1448,17 +1432,6 @@ class BinaryAggregate;
 class RealAggregate;
 class IntAggregate;
 
-#ifdef __OSTORE__
-typedef  STEPaggregate * (* AggregateCreator) (os_database *db) ;
-typedef  EnumAggregate * (* EnumAggregateCreator) (os_database *db) ;
-typedef  GenericAggregate * (* GenericAggregateCreator) (os_database *db) ;
-typedef  EntityAggregate * (* EntityAggregateCreator) (os_database *db) ;
-typedef  SelectAggregate * (* SelectAggregateCreator) (os_database *db) ;
-typedef  StringAggregate * (* StringAggregateCreator) (os_database *db) ;
-typedef  BinaryAggregate * (* BinaryAggregateCreator) (os_database *db) ;
-typedef  RealAggregate * (* RealAggregateCreator) (os_database *db) ;
-typedef  IntAggregate * (* IntAggregateCreator) (os_database *db) ;
-#else
 typedef  STEPaggregate * (* AggregateCreator) () ;
 typedef  EnumAggregate * (* EnumAggregateCreator) () ;
 typedef  GenericAggregate * (* GenericAggregateCreator) () ;
@@ -1468,25 +1441,7 @@ typedef  StringAggregate * (* StringAggregateCreator) () ;
 typedef  BinaryAggregate * (* BinaryAggregateCreator) () ;
 typedef  RealAggregate * (* RealAggregateCreator) () ;
 typedef  IntAggregate * (* IntAggregateCreator) () ;
-#endif
 
-#ifdef __OSTORE__
-EnumAggregate * create_EnumAggregate(os_database *db);
-
-GenericAggregate * create_GenericAggregate(os_database *db);
-
-EntityAggregate * create_EntityAggregate(os_database *db);
-
-SelectAggregate * create_SelectAggregate(os_database *db);
-
-StringAggregate * create_StringAggregate(os_database *db);
-
-BinaryAggregate * create_BinaryAggregate(os_database *db);
-
-RealAggregate * create_RealAggregate(os_database *db);
-
-IntAggregate * create_IntAggregate(os_database *db);
-#else
 EnumAggregate * create_EnumAggregate();
 
 GenericAggregate * create_GenericAggregate();
@@ -1502,7 +1457,7 @@ BinaryAggregate * create_BinaryAggregate();
 RealAggregate * create_RealAggregate();
 
 IntAggregate * create_IntAggregate();
-#endif
+
 ///////////////////////////////////////////////////////////////////////////////
 // AggrTypeDescriptor
 // I think we decided on a simplistic representation of aggr. types for now?
@@ -1532,11 +1487,7 @@ class AggrTypeDescriptor  :    public TypeDescriptor  {
 	CreateNewAggr = f;
     }
 
-#ifdef __OSTORE__
-    STEPaggregate *CreateAggregate(os_database *db);
-#else
     STEPaggregate *CreateAggregate();
-#endif
 
     AggrTypeDescriptor ( ); 
     AggrTypeDescriptor(SCLP23(Integer) b1, SCLP23(Integer) b2, 
@@ -1650,11 +1601,7 @@ class BagTypeDescriptor  :    public AggrTypeDescriptor  {
 
 };
 
-#ifdef __OSTORE__
-typedef  SCLP23(Select) * (* SelectCreator) (os_database *db) ;
-#else
 typedef  SCLP23(Select) * (* SelectCreator) () ;
-#endif
 
 class SelectTypeDescriptor  :    public TypeDescriptor  { 
 
@@ -1671,11 +1618,7 @@ class SelectTypeDescriptor  :    public TypeDescriptor  {
 	    CreateNewSelect = f;
 	}
 
-#ifdef __OSTORE__
-	SCLP23(Select) *CreateSelect(os_database *db);
-#else
 	SCLP23(Select) *CreateSelect();
-#endif
 
         SelectTypeDescriptor (int b, const char * nm, PrimitiveType ft, 
 			      Schema *origSchema, 

--- a/src/clstepcore/ExpDict.h.s
+++ b/src/clstepcore/ExpDict.h.s
@@ -14,10 +14,6 @@
 
 /* $Id: ExpDict.h,v 3.0.1.12 1998/02/17 19:19:15 sauderd DP3.1 $  */ 
 
-#ifdef __OSTORE__
-#include <ostore/ostore.hh>    // Required to access ObjectStore Class Library
-#endif
-
 #ifdef __O3DB__
 #include <OpenOODB.h>
 #endif
@@ -25,11 +21,7 @@
 #include <sdai.h>
 //class SCLP23(Application_instance);
 
-#if __OSTORE__
-typedef  SCLP23(Application_instance) * (* Creator) (os_database *) ;
-#else
 typedef  SCLP23(Application_instance) * (* Creator) () ;
-#endif
 //class StringAggregate;
 
 enum AttrType_Enum {
@@ -1189,11 +1181,7 @@ class TypeDescriptor {
 	        // is USE/REFERENCE'ing us (added to altNames).
 };
 
-#ifdef __OSTORE__
-typedef  SCLP23(Enum) * (* EnumCreator) (os_database *db) ;
-#else
 typedef  SCLP23(Enum) * (* EnumCreator) () ;
-#endif
 
 class EnumTypeDescriptor  :    public TypeDescriptor  { 
   public:
@@ -1206,11 +1194,7 @@ class EnumTypeDescriptor  :    public TypeDescriptor  {
 	CreateNewEnum = f;
     }
 
-#ifdef __OSTORE__
-    SCLP23(Enum) *CreateEnum(os_database *db);
-#else
     SCLP23(Enum) *CreateEnum();
-#endif
 
     EnumTypeDescriptor ( ) { }
     EnumTypeDescriptor (const char * nm, PrimitiveType ft, 
@@ -1352,17 +1336,6 @@ class BinaryAggregate;
 class RealAggregate;
 class IntAggregate;
 
-#ifdef __OSTORE__
-typedef  STEPaggregate * (* AggregateCreator) (os_database *db) ;
-typedef  EnumAggregate * (* EnumAggregateCreator) (os_database *db) ;
-typedef  GenericAggregate * (* GenericAggregateCreator) (os_database *db) ;
-typedef  EntityAggregate * (* EntityAggregateCreator) (os_database *db) ;
-typedef  SelectAggregate * (* SelectAggregateCreator) (os_database *db) ;
-typedef  StringAggregate * (* StringAggregateCreator) (os_database *db) ;
-typedef  BinaryAggregate * (* BinaryAggregateCreator) (os_database *db) ;
-typedef  RealAggregate * (* RealAggregateCreator) (os_database *db) ;
-typedef  IntAggregate * (* IntAggregateCreator) (os_database *db) ;
-#else
 typedef  STEPaggregate * (* AggregateCreator) () ;
 typedef  EnumAggregate * (* EnumAggregateCreator) () ;
 typedef  GenericAggregate * (* GenericAggregateCreator) () ;
@@ -1372,25 +1345,7 @@ typedef  StringAggregate * (* StringAggregateCreator) () ;
 typedef  BinaryAggregate * (* BinaryAggregateCreator) () ;
 typedef  RealAggregate * (* RealAggregateCreator) () ;
 typedef  IntAggregate * (* IntAggregateCreator) () ;
-#endif
 
-#ifdef __OSTORE__
-EnumAggregate * create_EnumAggregate(os_database *db);
-
-GenericAggregate * create_GenericAggregate(os_database *db);
-
-EntityAggregate * create_EntityAggregate(os_database *db);
-
-SelectAggregate * create_SelectAggregate(os_database *db);
-
-StringAggregate * create_StringAggregate(os_database *db);
-
-BinaryAggregate * create_BinaryAggregate(os_database *db);
-
-RealAggregate * create_RealAggregate(os_database *db);
-
-IntAggregate * create_IntAggregate(os_database *db);
-#else
 EnumAggregate * create_EnumAggregate();
 
 GenericAggregate * create_GenericAggregate();
@@ -1406,7 +1361,7 @@ BinaryAggregate * create_BinaryAggregate();
 RealAggregate * create_RealAggregate();
 
 IntAggregate * create_IntAggregate();
-#endif
+
 ///////////////////////////////////////////////////////////////////////////////
 // AggrTypeDescriptor
 // I think we decided on a simplistic representation of aggr. types for now?
@@ -1436,11 +1391,7 @@ class AggrTypeDescriptor  :    public TypeDescriptor  {
 	CreateNewAggr = f;
     }
 
-#ifdef __OSTORE__
-    STEPaggregate *CreateAggregate(os_database *db);
-#else
     STEPaggregate *CreateAggregate();
-#endif
 
     AggrTypeDescriptor ( ); 
     AggrTypeDescriptor(SCLP23(Integer) b1, SCLP23(Integer) b2, 
@@ -1554,11 +1505,7 @@ class BagTypeDescriptor  :    public AggrTypeDescriptor  {
 
 };
 
-#ifdef __OSTORE__
-typedef  SCLP23(Select) * (* SelectCreator) (os_database *db) ;
-#else
 typedef  SCLP23(Select) * (* SelectCreator) () ;
-#endif
 
 class SelectTypeDescriptor  :    public TypeDescriptor  { 
 
@@ -1575,11 +1522,7 @@ class SelectTypeDescriptor  :    public TypeDescriptor  {
 	    CreateNewSelect = f;
 	}
 
-#ifdef __OSTORE__
-	SCLP23(Select) *CreateSelect(os_database *db);
-#else
 	SCLP23(Select) *CreateSelect();
-#endif
 
         SelectTypeDescriptor (int b, const char * nm, PrimitiveType ft, 
 			      Schema *origSchema, 

--- a/src/clstepcore/Registry.h
+++ b/src/clstepcore/Registry.h
@@ -14,10 +14,6 @@
 
 /* $Id: Registry.h,v 3.0.1.7 1997/11/05 21:59:19 sauderd DP3.1 $  */ 
 
-#ifdef __OSTORE__
-#include <ostore/ostore.hh>    // Required to access ObjectStore Class Library
-#endif
-
 #include <sdai.h>
 //#include <STEPentity.h>
 #include <errordesc.h>
@@ -83,14 +79,8 @@ class Registry {
     const ComplexCollect *CompCol() { return col; }
     void        SetCompCollect( ComplexCollect *c ) { col = c; }
 
-#ifdef __OSTORE__
-    SCLP23(Application_instance)* ObjCreate (const char * nm, os_database *db =0,
-			   const char * =0, int check_case =0) const;
-#else
     SCLP23(Application_instance)* ObjCreate (const char * nm, const char * =0,
 			   int check_case =0) const;
-#endif
-    
 };
 
 #endif  /*  _REGISTRY_H  */

--- a/src/clstepcore/Registry.inline.cc
+++ b/src/clstepcore/Registry.inline.cc
@@ -1,7 +1,3 @@
-#ifdef __OSTORE__
-extern int pr_obj_errors;
-#endif
-
 /*
 * NIST STEP Core Class Library
 * clstepcore/Registry.inline.cc
@@ -28,24 +24,11 @@ extern int pr_obj_errors;
 
 static int uniqueNames( const char *, const SchRename * );
 
-//#ifdef __OSTORE__
-//Registry::Registry (CF_init initFunct, os_database *db) 
-//#else
 Registry::Registry (CF_init initFunct) 
-//#endif
 : entity_cnt(0), all_ents_cnt(0), col(0)
 { 
-//#ifdef __OSTORE__
-    // need to make this thing persistent in a database - DAS
-/*
-    if(NilSTEPentity == 0)
-      NilSTEPentity = new (db, SCLP23(Application_instance)::get_os_typespec())
-				SCLP23(Application_instance);
-*/
-//#else
 //    if(NilSTEPentity == 0)
 //      NilSTEPentity = new SCLP23(Application_instance);
-//#endif
 
     /* Registry tables aren't always initialized */
     HASHinitialize();
@@ -319,46 +302,6 @@ Registry::RemoveClones (const EntityDescriptor& e)
     }
 }
 
-#ifdef __OSTORE__
-SCLP23(Application_instance) * 
-Registry::ObjCreate (const char *nm, os_database *db, const char *schnm,
-		     int check_case) const
-{
-    if(pr_obj_errors > 3)
-      cout << "Registry::ObjCreate() db ptr: " << db << endl;
-
-    const EntityDescriptor *  entd = FindEntity (nm, schnm, check_case);
-    if (entd)
-    {
-	SCLP23(Application_instance) *se = 
-	  ((EntityDescriptor *)entd) -> NewSTEPentity (db);
-
-	if(pr_obj_errors > 3)
-	{
-	    cout << "Created entity: " << se->EntityName() << endl;
-	    cout << "os_database::of(se) in Registry::ObjCreate(): "
-	      << os_database::of(se) << endl;
-	}
-	// If se is an abstract supertype or a complex entity which requires
-	// external mapping it shouldn't be instantiable using ObjCreate() (but
-	// rather as a part of a STEPcomplex).  In such cases we do create one
-	// here, but we check these conditions and set se's ErrorDescriptor
-	// field appropriately.
-	if ( entd->AbstractEntity().asInt() == TRUE ) {
-	    se->Error().severity( SEVERITY_WARNING );
-	    se->Error().UserMsg( "ENTITY is abstract supertype" );
-	} else if ( entd->ExtMapping().asInt() == TRUE ) {
-	    se->Error().severity( SEVERITY_WARNING );
-	    se->Error().UserMsg( "ENTITY requires external mapping" );
-	}
-	return se;
-    }
-    else {
-        return ENTITY_NULL;
-    }
-}
-
-#else
 
 SCLP23(Application_instance) *
 Registry::ObjCreate (const char *nm, const char *schnm, int check_case) const
@@ -381,7 +324,7 @@ Registry::ObjCreate (const char *nm, const char *schnm, int check_case) const
 	return ENTITY_NULL;
     }
 }
-#endif
+
 
 /* inline */ int
 Registry::GetEntityCnt ()

--- a/src/clstepcore/STEPaggregate.cc
+++ b/src/clstepcore/STEPaggregate.cc
@@ -436,12 +436,7 @@ GenericAggregate::~GenericAggregate()
 SingleLinkNode *
 GenericAggregate::NewNode () 
 {
-#ifdef __OSTORE__
-    return new (os_segment::of(this),
-		GenericAggrNode::get_os_typespec()) GenericAggrNode();
-#else
     return new GenericAggrNode();
-#endif
 }
 
 STEPaggregate& 
@@ -454,13 +449,7 @@ GenericAggregate::ShallowCopy (const STEPaggregate& a)
 
     while (next) 
     {
-#ifdef __OSTORE__
-	copy = new (os_segment::of(this), 
-		    GenericAggrNode::get_os_typespec()) 
-				GenericAggrNode (*(GenericAggrNode*)next);
-#else
 	copy = new GenericAggrNode (*(GenericAggrNode*)next);
-#endif
 	AddNode(copy);
 	next = next->NextNode();
     }
@@ -497,12 +486,7 @@ GenericAggrNode::~GenericAggrNode()
 SingleLinkNode *
 GenericAggrNode::NewNode () 
 {
-#ifdef __OSTORE__
-    return new (os_segment::of(this), 
-		GenericAggrNode::get_os_typespec()) GenericAggrNode();
-#else
     return new GenericAggrNode();
-#endif
 }
 
 Severity 
@@ -630,20 +614,13 @@ EntityAggregate::ReadValue(istream &in, ErrorDescriptor *err,
     // if not assigning values only need one node. So only one node is created.
     // It is used to read the values
     else if(!assignVal) 
-      // OSTORE note - since this is temporary and deleted anyway don't worry
-      // about persistent new
 	item = new EntityNode();
 
     while (in.good() && (c != ')') )
     {
 	value_cnt++;
 	if(assignVal) // create a new node each time through the loop
-#ifdef __OSTORE__
-	    item = new (os_segment::of(this), 
-			EntityNode::get_os_typespec()) EntityNode();
-#else
 	    item = new EntityNode();
-#endif
 
 	errdesc.ClearErrorMsg();
 
@@ -715,12 +692,7 @@ EntityAggregate::ShallowCopy (const STEPaggregate& a)
     const EntityNode * tmp = (const EntityNode*) a.GetHead ();
     while (tmp) 
     {
-#ifdef __OSTORE__
-	AddNode (new (os_segment::of(this), 
-		      EntityNode::get_os_typespec()) EntityNode (tmp -> node));
-#else
 	AddNode (new EntityNode (tmp -> node));
-#endif
 	tmp = (const EntityNode*) tmp -> NextNode ();
     }
     if(head)
@@ -735,12 +707,7 @@ EntityAggregate::ShallowCopy (const STEPaggregate& a)
 SingleLinkNode *	
 EntityAggregate::NewNode ()  
 {
-#ifdef __OSTORE__
-    return new (os_segment::of(this), 
-		EntityNode::get_os_typespec()) EntityNode();
-#else
     return new EntityNode();
-#endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -762,12 +729,7 @@ EntityNode::EntityNode  (SCLP23(Application_instance) * e) : node (e)
 SingleLinkNode *	
 EntityNode::NewNode ()  
 {
-#ifdef __OSTORE__
-    return new (os_segment::of(this), 
-		EntityNode::get_os_typespec()) EntityNode();
-#else
     return new EntityNode();
-#endif
 }
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -1013,12 +975,7 @@ SelectAggregate::ShallowCopy (const STEPaggregate& a)
     const SelectNode * tmp = (const SelectNode*) a.GetHead ();
     while (tmp) 
     {
-#ifdef __OSTORE__
-	AddNode (new (os_segment::of(this), 
-		      SelectNode::get_os_typespec()) SelectNode (tmp -> node));
-#else
 	AddNode (new SelectNode (tmp -> node));
-#endif
 
 	tmp = (const SelectNode*) tmp -> NextNode ();
     }
@@ -1034,12 +991,7 @@ SelectAggregate::ShallowCopy (const STEPaggregate& a)
 SingleLinkNode *	
 SelectAggregate::NewNode ()  
 {
-#ifdef __OSTORE__
-    return new (os_segment::of(this), 
-		SelectNode::get_os_typespec()) SelectNode();
-#else
     return new SelectNode();
-#endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1061,12 +1013,7 @@ SelectNode::~SelectNode()
 SingleLinkNode *	
 SelectNode::NewNode ()  
 {
-#ifdef __OSTORE__
-    return new (os_segment::of(this), 
-		SelectNode::get_os_typespec()) SelectNode();
-#else
     return new SelectNode();
-#endif
 }
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -1196,13 +1143,7 @@ StringAggregate::ShallowCopy (const STEPaggregate& a)
 
     while (next) 
     {
-#ifdef __OSTORE__
-	copy = new (os_segment::of(this), 
-		    StringNode::get_os_typespec()) 
-				StringNode (*(StringNode*)next);
-#else
 	copy = new StringNode (*(StringNode*)next);
-#endif
 	AddNode(copy);
 	next = next->NextNode();
     }
@@ -1217,12 +1158,7 @@ StringAggregate::ShallowCopy (const STEPaggregate& a)
 SingleLinkNode *
 StringAggregate::NewNode () 
 {
-#ifdef __OSTORE__
-    return new (os_segment::of(this), 
-		StringNode::get_os_typespec()) StringNode();
-#else
     return new StringNode();
-#endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1259,12 +1195,7 @@ StringNode::StringNode(const char * sStr)
 SingleLinkNode *
 StringNode::NewNode () 
 {
-#ifdef __OSTORE__
-    return new (os_segment::of(this), 
-		StringNode::get_os_typespec()) StringNode();
-#else
     return new StringNode();
-#endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1354,13 +1285,7 @@ BinaryAggregate::ShallowCopy (const STEPaggregate& a)
 
     while (next) 
     {
-#ifdef __OSTORE__
-	copy = new (os_segment::of(this), 
-		    BinaryNode::get_os_typespec()) 
-				BinaryNode (*(BinaryNode*)next);
-#else
 	copy = new BinaryNode (*(BinaryNode*)next);
-#endif
 	AddNode(copy);
 	next = next->NextNode();
     }
@@ -1375,12 +1300,7 @@ BinaryAggregate::ShallowCopy (const STEPaggregate& a)
 SingleLinkNode *
 BinaryAggregate::NewNode () 
 {
-#ifdef __OSTORE__
-    return new (os_segment::of(this), 
-		BinaryNode::get_os_typespec()) BinaryNode();
-#else
     return new BinaryNode();
-#endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1410,12 +1330,7 @@ BinaryNode::BinaryNode(const char *sStr)
 SingleLinkNode *
 BinaryNode::NewNode () 
 {
-#ifdef __OSTORE__
-    return new (os_segment::of(this), 
-		BinaryNode::get_os_typespec()) BinaryNode();
-#else
     return new BinaryNode();
-#endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1733,28 +1648,14 @@ LOGICALS::~LOGICALS()
 SingleLinkNode *
 LOGICALS::NewNode ()  
 {
-#ifdef __OSTORE__
-    return new (os_segment::of(this), EnumNode::get_os_typespec()) 
-			EnumNode( new (os_segment::of(this), 
-				       SCLP23(LOGICAL)::get_os_typespec()) SCLP23(LOGICAL) );
-#else
     return new EnumNode (new SCLP23(LOGICAL));
-#endif
 }	
 
-#ifdef __OSTORE__
-LOGICALS * 
-create_LOGICALS(os_database *db)
-{
-    return new (db, LOGICALS::get_os_typespec()) LOGICALS;
-}
-#else
 LOGICALS * 
 create_LOGICALS()
 {
     return new LOGICALS;
 }
-#endif
 
 ///////////////////////////////////////////////////////////////////////////////
 // BOOLEANS
@@ -1772,28 +1673,14 @@ BOOLEANS::~BOOLEANS()
 SingleLinkNode *
 BOOLEANS::NewNode ()  
 {
-#ifdef __OSTORE__
-    return new (os_segment::of(this), EnumNode::get_os_typespec()) 
-			EnumNode( new (os_segment::of(this), 
-				       SCLP23(BOOLEAN)::get_os_typespec()) SCLP23(BOOLEAN) );
-#else
     return new EnumNode (new SCLP23(BOOLEAN));
-#endif
 }	
 
-#ifdef __OSTORE__
-BOOLEANS * 
-create_BOOLEANS(os_database *db)
-{
-    return new (db, BOOLEANS::get_os_typespec()) BOOLEANS;
-}
-#else
 BOOLEANS * 
 create_BOOLEANS()
 {
     return new BOOLEANS ; 
 }
-#endif
 
 ///////////////////////////////////////////////////////////////////////////////
 // RealAggregate
@@ -1810,12 +1697,7 @@ RealAggregate::~RealAggregate()
 SingleLinkNode *
 RealAggregate::NewNode ()  
 {
-#ifdef __OSTORE__
-    return new (os_segment::of(this), 
-		RealNode::get_os_typespec()) RealNode();
-#else
     return new RealNode();
-#endif
 }	
 
 // COPY
@@ -1854,12 +1736,7 @@ IntAggregate::~IntAggregate()
 SingleLinkNode *
 IntAggregate::NewNode ()  
 {
-#ifdef __OSTORE__
-    return new (os_segment::of(this), 
-		IntNode::get_os_typespec()) IntNode();
-#else
     return new IntNode();
-#endif
 }	
 
 // COPY
@@ -1899,12 +1776,7 @@ RealNode::~RealNode()
 SingleLinkNode *
 RealNode::NewNode ()  
 {
-#ifdef __OSTORE__
-    return new (os_segment::of(this), 
-		RealNode::get_os_typespec()) RealNode();
-#else
     return new RealNode();
-#endif
 }	
 
 Severity 
@@ -2002,12 +1874,7 @@ IntNode::~IntNode()
 SingleLinkNode *
 IntNode::NewNode ()  
 {
-#ifdef __OSTORE__
-    return new (os_segment::of(this), 
-		IntNode::get_os_typespec()) IntNode();
-#else
     return new IntNode();
-#endif
 }	
 
 Severity 

--- a/src/clstepcore/STEPaggregate.h
+++ b/src/clstepcore/STEPaggregate.h
@@ -107,10 +107,6 @@ class STEPaggregate :  public SingleLinkList
 // COPY - defined in subtypes
     virtual STEPaggregate& ShallowCopy (const STEPaggregate&);
 
-#ifdef __OSTORE__
-    static os_typespec* get_os_typespec();
-#endif
-
 };									      
 
 /******************************************************************
@@ -128,9 +124,6 @@ class GenericAggregate  :  public STEPaggregate
     GenericAggregate();
     virtual ~GenericAggregate();
 
-#ifdef __OSTORE__
-    static os_typespec* get_os_typespec();
-#endif
 };
 typedef  GenericAggregate * GenericAggregateH;
 typedef  GenericAggregate * GenericAggregate_ptr;
@@ -155,9 +148,6 @@ class EntityAggregate  :  public  STEPaggregate
     EntityAggregate ();
     virtual ~EntityAggregate ();
 
-#ifdef __OSTORE__
-    static os_typespec* get_os_typespec();
-#endif
 };
 typedef   EntityAggregate * EntityAggregateH;
 typedef   EntityAggregate * EntityAggregate_ptr;
@@ -183,9 +173,6 @@ class SelectAggregate  :  public STEPaggregate
     SelectAggregate ();
     virtual ~SelectAggregate ();
 
-#ifdef __OSTORE__
-    static os_typespec* get_os_typespec();
-#endif
 };
 typedef  SelectAggregate *  SelectAggregateH;
 typedef  SelectAggregate *  SelectAggregate_ptr;
@@ -204,9 +191,6 @@ class StringAggregate  :  public STEPaggregate
     StringAggregate();
     virtual ~StringAggregate();
 
-#ifdef __OSTORE__
-    static os_typespec* get_os_typespec();
-#endif
 };
 typedef  StringAggregate * StringAggregateH;
 typedef  StringAggregate * StringAggregate_ptr;
@@ -226,9 +210,6 @@ class BinaryAggregate  :  public STEPaggregate
     BinaryAggregate();
     virtual ~BinaryAggregate();
 
-#ifdef __OSTORE__
-    static os_typespec* get_os_typespec();
-#endif
 };
 typedef  BinaryAggregate * BinaryAggregateH;
 typedef  BinaryAggregate * BinaryAggregate_ptr;
@@ -248,9 +229,6 @@ class EnumAggregate  :  public STEPaggregate
     EnumAggregate ();
   virtual ~EnumAggregate ();
 
-#ifdef __OSTORE__
-    static os_typespec* get_os_typespec();
-#endif
 };
 typedef  EnumAggregate *  EnumAggregateH;
 typedef  EnumAggregate *  EnumAggregate_ptr;
@@ -264,18 +242,11 @@ class LOGICALS  : public EnumAggregate
     LOGICALS();
     virtual ~LOGICALS();
 
-#ifdef __OSTORE__
-    static os_typespec* get_os_typespec();
-#endif
 };
 typedef  LOGICALS *  LogicalsH;
 typedef  LOGICALS *  LOGICALS_ptr;
 typedef  LOGICALS_ptr LOGICALS_var;
-#ifdef __OSTORE__
-LOGICALS * create_LOGICALS(os_database *db);
-#else
 LOGICALS * create_LOGICALS();
-#endif
 
 
 class BOOLEANS  : public EnumAggregate  
@@ -286,20 +257,13 @@ class BOOLEANS  : public EnumAggregate
     BOOLEANS();
     virtual ~BOOLEANS();
 
-#ifdef __OSTORE__
-    static os_typespec* get_os_typespec();
-#endif
 };
 
 //typedef  BOOLEANS *  BooleansH;
 typedef  BOOLEANS *  BOOLEANS_ptr;
 typedef  BOOLEANS_ptr BOOLEANS_var;
 
-#ifdef __OSTORE__
-BOOLEANS * create_BOOLEANS(os_database *db);
-#else
 BOOLEANS * create_BOOLEANS();
-#endif
 
 class RealAggregate  : public STEPaggregate  {
 
@@ -310,9 +274,6 @@ class RealAggregate  : public STEPaggregate  {
     RealAggregate();
     virtual ~RealAggregate();
 
-#ifdef __OSTORE__
-    static os_typespec* get_os_typespec();
-#endif
 };
 typedef  RealAggregate *  RealAggregateH;
 typedef  RealAggregate *  RealAggregate_ptr;
@@ -327,9 +288,6 @@ class IntAggregate  : public STEPaggregate  {
     IntAggregate();
     virtual ~IntAggregate();
 
-#ifdef __OSTORE__
-    static os_typespec* get_os_typespec();
-#endif
 };
 typedef  IntAggregate *  IntAggregateH;
 typedef  IntAggregate *  IntAggregate_ptr;
@@ -360,9 +318,6 @@ class STEPnode :  public SingleLinkNode  {
     virtual const char *asStr(SCLstring & s);
     virtual const char *STEPwrite(SCLstring &s, const char * =0);
     virtual void STEPwrite (ostream& out =cout);
-#ifdef __OSTORE__
-    static os_typespec* get_os_typespec();
-#endif
 };
 typedef  STEPnode *  STEPnodeH;
 
@@ -396,10 +351,6 @@ class GenericAggrNode  : public STEPnode {
     ~GenericAggrNode ();
 
     virtual SingleLinkNode *	NewNode ();
-
-#ifdef __OSTORE__
-    static os_typespec* get_os_typespec();
-#endif
 
 };
 
@@ -462,9 +413,6 @@ class EntityNode  : public STEPnode {
 	return STEPread(in, err, 0, 0, 0);
     }
 
-#ifdef __OSTORE__
-    static os_typespec* get_os_typespec();
-#endif
 };
 
 ///////////////////////////////////////////////////////////////////////////
@@ -536,9 +484,6 @@ class SelectNode  : public STEPnode {
 	return STEPread(in, err, 0, 0, 0);
     }
 
-#ifdef __OSTORE__
-    static os_typespec* get_os_typespec();
-#endif
 };
 
 ///////////////////////////////////////////////////////////////////////////
@@ -574,9 +519,6 @@ class StringNode  : public STEPnode {
 
     virtual SingleLinkNode *	NewNode ();
 
-#ifdef __OSTORE__
-    static os_typespec* get_os_typespec();
-#endif
 };
 
 ///////////////////////////////////////////////////////////////////////////
@@ -612,9 +554,6 @@ class BinaryNode  : public STEPnode {
 
     virtual SingleLinkNode *	NewNode ();
 
-#ifdef __OSTORE__
-    static os_typespec* get_os_typespec();
-#endif
 };
 
 /******************************************************************
@@ -648,9 +587,6 @@ class EnumNode  : public STEPnode {
 
     virtual SingleLinkNode *	NewNode ();
 
-#ifdef __OSTORE__
-    static os_typespec* get_os_typespec();
-#endif
 };
 
 class RealNode  : public STEPnode {
@@ -676,9 +612,6 @@ class RealNode  : public STEPnode {
 
     virtual SingleLinkNode *	NewNode ();
 
-#ifdef __OSTORE__
-    static os_typespec* get_os_typespec();
-#endif
 };
 
 class IntNode  : public STEPnode {
@@ -704,9 +637,6 @@ class IntNode  : public STEPnode {
 
     virtual SingleLinkNode *	NewNode ();
 
-#ifdef __OSTORE__
-    static os_typespec* get_os_typespec();
-#endif
 };
 
 /******************************************************************

--- a/src/clstepcore/STEPattribute.h
+++ b/src/clstepcore/STEPattribute.h
@@ -16,10 +16,6 @@
 
 #include <sclprefixes.h>
 
-#ifdef __OSTORE__
-#include <ostore/ostore.hh>    // Required to access ObjectStore Class Library
-#endif
-
 #ifdef __O3DB__
 #include <OpenOODB.h>
 #endif
@@ -193,9 +189,6 @@ class STEPattribute {
 
     Severity ValidLevel (const char *attrValue, ErrorDescriptor *error, 
 			     InstMgr *im, int clearError = 1);
-#ifdef __OSTORE__
-    static os_typespec* get_os_typespec();
-#endif
   public:
 
 ////////////////// Constructors

--- a/src/clstepcore/STEPattributeList.cc
+++ b/src/clstepcore/STEPattributeList.cc
@@ -60,12 +60,7 @@ int STEPattributeList::list_length()
 
 void STEPattributeList::push(STEPattribute *a)
 {
-#ifdef __OSTORE__
-    AttrListNode *saln = new (os_database::of(this), 
-			      AttrListNode::get_os_typespec()) AttrListNode(a);
-#else
     AttrListNode *saln = new AttrListNode(a);
-#endif
     AppendNode (saln);
 }
 

--- a/src/clstepcore/STEPattributeList.h
+++ b/src/clstepcore/STEPattributeList.h
@@ -15,10 +15,6 @@
 
 /* $Id: STEPattributeList.h,v 3.0.1.3 1997/11/05 21:59:25 sauderd DP3.1 $ */
 
-#ifdef __OSTORE__
-#include <ostore/ostore.hh>    // Required to access ObjectStore Class Library
-#endif
-
 #ifdef __O3DB__
 #include <OpenOODB.h>
 #endif
@@ -45,9 +41,6 @@ class AttrListNode :  public SingleLinkNode
     AttrListNode(STEPattribute *a);
     virtual ~AttrListNode();
 
-#ifdef __OSTORE__
-    static os_typespec* get_os_typespec();
-#endif
 };
 
 class STEPattributeList : public SingleLinkList
@@ -59,10 +52,6 @@ class STEPattributeList : public SingleLinkList
     STEPattribute& operator [] (int n);
     int list_length();
     void push(STEPattribute *a);
-
-#ifdef __OSTORE__
-    static os_typespec* get_os_typespec();
-#endif
 };
 
 /*****************************************************************

--- a/src/clstepcore/STEPcomplex.cc
+++ b/src/clstepcore/STEPcomplex.cc
@@ -524,22 +524,14 @@ STEPcomplex::BuildAttrs(const char *s )
 		  {
 		    EnumTypeDescriptor * enumD = 
 				(EnumTypeDescriptor *)ad->ReferentType();
-#ifdef __OSTORE__
-		    a = new STEPattribute (*ad,  enumD->CreateEnum(os_database::of(this)) );
-#else
 		    a = new STEPattribute (*ad,  enumD->CreateEnum() );
-#endif
 		    break;
 		  }
 		  case SELECT_TYPE:
 		  {
 		    SelectTypeDescriptor * selectD = 
 				(SelectTypeDescriptor *)ad->ReferentType();
-#ifdef __OSTORE__
-		    a = new STEPattribute (*ad,  selectD->CreateSelect(os_database::of(this)) );
-#else
 		    a = new STEPattribute (*ad,  selectD->CreateSelect() );
-#endif
 		    break;
 		  }
 		  case AGGREGATE_TYPE:
@@ -550,11 +542,7 @@ STEPcomplex::BuildAttrs(const char *s )
 		  {
 		    AggrTypeDescriptor * aggrD = 
 				(AggrTypeDescriptor *)ad->ReferentType();
-#ifdef __OSTORE__
-		    a = new STEPattribute (*ad,  aggrD->CreateAggregate(os_database::of(this)) );
-#else
 		    a = new STEPattribute (*ad,  aggrD->CreateAggregate() );
-#endif
 		    break;
 		  }
 		}

--- a/src/clstepcore/SingleLinkList.h
+++ b/src/clstepcore/SingleLinkList.h
@@ -14,10 +14,6 @@
 
 /* $Id: SingleLinkList.h,v 3.0.1.4 1997/11/05 21:59:22 sauderd DP3.1 $ */
 
-#ifdef __OSTORE__
-#include <ostore/ostore.hh>    // Required to access ObjectStore Class Library
-#endif
-
 #ifdef __O3DB__
 #include <OpenOODB.h>
 #endif
@@ -47,9 +43,6 @@ class SingleLinkList  {
     SingleLinkList ();
     virtual ~SingleLinkList ();
 
-#ifdef __OSTORE__
-    static os_typespec* get_os_typespec();
-#endif
 }
 ;
 
@@ -66,9 +59,6 @@ class SingleLinkNode {
     SingleLinkNode() : owner(0), next(0)  { }
     virtual ~SingleLinkNode() { }
 
-#ifdef __OSTORE__
-    static os_typespec* get_os_typespec();
-#endif
 };
 
 #endif

--- a/src/clstepcore/sdai.h
+++ b/src/clstepcore/sdai.h
@@ -38,15 +38,6 @@ extern const char *SCLversion;
 #include <corbaIncludes.h>
 #endif
 
-#ifdef __OSTORE__
-
-#include <ostore/ostore.hh>    // Required to access ObjectStore Class Library
-#include <ostore/coll.hh>
-void Application_instance_access_hook_in(void *object, 
-	enum os_access_reason reason, void *user_data, 
-	void *start_range, void *end_range);
-
-#endif
 
 #include <sclprefixes.h>
 #include <dictdefs.h>
@@ -397,17 +388,9 @@ AGGREGATE TYPES
 
 ******************************************************************************/
 
-#ifdef __OSTORE__
-SCLP23(BOOLEAN) *create_BOOLEAN(os_database *db);
-#else
 inline SCLP23(BOOLEAN) *create_BOOLEAN() { return new SCLP23(BOOLEAN) ; }
-#endif
 
-#ifdef __OSTORE__
-SCLP23(LOGICAL) *create_LOGICAL(os_database *db);
-#else
 inline SCLP23(LOGICAL) *create_LOGICAL() { return new SCLP23(LOGICAL) ; }
-#endif
 
 // below is outdated
 typedef SCLP23(Select) * SdaiSelectH;

--- a/src/clstepcore/sdaiApplication_instance.cc
+++ b/src/clstepcore/sdaiApplication_instance.cc
@@ -103,11 +103,7 @@ SCLP23(Application_instance)::Replicate()
     }
     else
     {
-#ifdef __OSTORE__
-	SCLP23(Application_instance) *seNew = eDesc->NewSTEPentity(os_database::of(this));
-#else
 	SCLP23(Application_instance) *seNew = eDesc->NewSTEPentity();
-#endif
 	seNew -> CopyAs (this);
 	return seNew;
     }
@@ -224,32 +220,6 @@ SCLP23(Application_instance)::GetMiEntity(char *EntityName)
 }
 
 
-#ifdef __OSTORE__
-void Application_instance_access_hook_in(void *object, 
-	enum os_access_reason reason, void *user_data, 
-	void *start_range, void *end_range)
-{
-    cout << "ObjectStore called non-member function Application_instance Access_hook" 
-      << endl;
-    SCLP23(Application_instance) *ent = (SCLP23(Application_instance) *)object;
-    cout << "STEPfile_id: " << ent->STEPfile_id << endl;
-    ent->Access_hook_in(object, reason, user_data, start_range, end_range);
-
-//    SdaiEb_person *ent = (SdaiEb_person *)object;
-//    SdaiEb_person_access_hook_in(object, reason, user_data, 
-//				 start_range, end_range);
-}
-
-void 
-SCLP23(Application_instance)::Access_hook_in(void *object, 
-			   enum os_access_reason reason, void *user_data, 
-			   void *start_range, void *end_range)
-{
-    SCLP23(Application_instance) *ent = (SCLP23(Application_instance) *)object;
-    cout << "****WARNING: virtual SCLP23(Application_instance)::Access_hook_in() called" << endl;
-    ent->Access_hook_in(object, reason, user_data, start_range, end_range);
-}
-#endif
 
 STEPattribute * 
 SCLP23(Application_instance)::GetSTEPattribute (const char * nm)

--- a/src/clstepcore/sdaiApplication_instance.h
+++ b/src/clstepcore/sdaiApplication_instance.h
@@ -19,13 +19,6 @@
 
 /* $Id: sdaiApplication_instance.h,v 1.5 1998/02/17 18:29:43 sauderd DP3.1 $ */
 
-//#ifdef __OSTORE__
-//#include <ostore/ostore.hh>    // Required to access ObjectStore Class Library
-//void Application_instance_access_hook_in(void *object, 
-//	enum os_access_reason reason, void *user_data, 
-//	void *start_range, void *end_range);
-//#endif
-
 //#ifdef __O3DB__
 //#include <OpenOODB.h>
 //#endif
@@ -175,13 +168,6 @@ class SCLP23_NAME(Application_instance) : public SCLP23_NAME(DAObject_SDAI)
     SCLP23_NAME(Application_instance) *GetNextMiEntity() { return nextMiEntity; }
     SCLP23_NAME(Application_instance) *GetMiEntity(char *EntityName);
     void AppendMultInstance(SCLP23_NAME(Application_instance) *se);
-
-#ifdef __OSTORE__
-    static os_typespec* get_os_typespec();
-    virtual void Access_hook_in(void *object, 
-	enum os_access_reason reason, void *user_data, 
-	void *start_range, void *end_range);
-#endif
 
  protected:
     STEPattribute * GetSTEPattribute (const char *);

--- a/src/clstepcore/sdaiBinary.h
+++ b/src/clstepcore/sdaiBinary.h
@@ -71,10 +71,6 @@ class SCLP23_NAME(Binary) : public SCLstring
 			       int optional, char *tokenList,
 			       int needDelims = 0, int clearError = 1);
 
-#ifdef __OSTORE__
-    static os_typespec* get_os_typespec();
-#endif
-
  protected:
   Severity ReadBinary(istream& in, ErrorDescriptor *err, int AssignVal = 1,
 		      int needDelims = 1);

--- a/src/clstepcore/sdaiEnum.cc
+++ b/src/clstepcore/sdaiEnum.cc
@@ -41,13 +41,6 @@ const SCLP23(LOGICAL) SCLP23(UNKNOWN)( LUnknown );
 // class Logical
 ///////////////////////////////////////////////////////////////////////////////
 
-#ifdef __OSTORE__
-SCLP23(LOGICAL) * create_LOGICAL(os_database *db) 
-{
-    return new (db, SCLP23(LOGICAL)::get_os_typespec()) SCLP23(LOGICAL);
-}
-#endif
-
 SCLP23(LOGICAL)::SCLP23_NAME(LOGICAL) (char * val)
 {
     set_value (val);
@@ -81,17 +74,6 @@ SCLP23(LOGICAL)::SCLP23_NAME(LOGICAL) (const BOOLEAN& boo)
 SCLP23(LOGICAL)::~SCLP23_NAME(LOGICAL) () 
 {
 }
-
-#ifdef __OSTORE__
-void 
-SCLP23(LOGICAL)::Access_hook_in(void *object, 
-				enum os_access_reason reason, void *user_data, 
-				void *start_range, void *end_range)
-{
-    cout << "ObjectStore called LOGICAL::Access_hook_in()" 
-      << endl;
-}
-#endif
 
 const char * 
 SCLP23(LOGICAL)::Name() const
@@ -357,14 +339,6 @@ SCLP23(LOGICAL)::ReadEnum(istream& in, ErrorDescriptor *err, int AssignVal,
 // class BOOLEAN  Jan 97
 ///////////////////////////////////////////////////////////////////////////////
 
-#ifdef __OSTORE__
-SCLP23(BOOLEAN) * 
-create_BOOLEAN(os_database *db) 
-{
-    return new (db, SCLP23(BOOLEAN)::get_os_typespec()) SCLP23(BOOLEAN); 
-}
-#endif
-
 const char * 
 SCLP23(BOOLEAN)::Name() const
 {
@@ -411,17 +385,6 @@ SCLP23(BOOLEAN)::SCLP23_NAME(BOOLEAN) (const SCLP23(LOGICAL)& val)  {
   }
   set_value (val);
 }
-
-#ifdef __OSTORE__
-void 
-SCLP23(BOOLEAN)::Access_hook_in(void *object, 
-				enum os_access_reason reason, void *user_data, 
-				void *start_range, void *end_range)
-{
-    cout << "ObjectStore called BOOLEAN::Access_hook_in()" 
-      << endl;
-}
-#endif
 
 SCLP23(BOOLEAN)::operator  Boolean () const  {
   switch (v) {
@@ -493,17 +456,6 @@ SCLP23(Enum)::SCLP23_NAME(Enum)()
 SCLP23(Enum)::~SCLP23_NAME(Enum)()
 { 
 }
-
-#ifdef __OSTORE__
-void 
-SCLP23(Enum)::Access_hook_in(void *object, 
-				enum os_access_reason reason, void *user_data, 
-				void *start_range, void *end_range)
-{
-    cout << "ObjectStore called Enum::Access_hook_in()" 
-      << endl;
-}
-#endif
 
 int 
 SCLP23(Enum)::put(int val)

--- a/src/clstepcore/sdaiEnum.h
+++ b/src/clstepcore/sdaiEnum.h
@@ -21,10 +21,6 @@
 #include <corbaIncludes.h>
 #endif
 
-#ifdef __OSTORE__
-#include <ostore/ostore.hh>    // Required to access ObjectStore Class Library
-#endif
-
 #ifdef __O3DB__
 #include <OpenOODB.h>
 #endif
@@ -94,13 +90,6 @@ class SCLP23_NAME(Enum)  {
 			// unset is generated to be 1 greater than last element
     void DebugDisplay (ostream& out =cout) const;
 
-#ifdef __OSTORE__
-    static os_typespec* get_os_typespec();
-    virtual void Access_hook_in(void *object, 
-	enum os_access_reason reason, void *user_data, 
-	void *start_range, void *end_range);
-#endif
-
   protected:
     virtual Severity ReadEnum(istream& in, ErrorDescriptor *err, 
 			      int AssignVal = 1, int needDelims = 1);
@@ -154,13 +143,12 @@ public SCLP23_NAME(Enum)  {
     SCLP23_NAME(LOGICAL) (int i);
 
 // this is to avoid a bug? in the ossg utility for ObjectStore
-#ifndef __OSTORE__
 #ifndef _ODI_OSSG_
 // this causes an error with sun C++ because SCLP23_NAME(BOOLEAN) is not a completely 
 // specified type. (this is supposed to be SDAI?) DAS
 //    SCLP23_NAME(LOGICAL) (const SCLP23_NAME(BOOLEAN)& boo);
 #endif
-#endif
+
     virtual ~SCLP23_NAME(LOGICAL) ();
 
     virtual int no_elements () const;
@@ -175,13 +163,6 @@ public SCLP23_NAME(Enum)  {
     // these 2 are redefined because LUnknown has cardinal value > LUnset
     int exists() const; // return 0 if unset otherwise return 1
     void nullify(); // change the receiver to an unset status
-
-#ifdef __OSTORE__
-    static os_typespec* get_os_typespec();
-    virtual void Access_hook_in(void *object, 
-	enum os_access_reason reason, void *user_data, 
-	void *start_range, void *end_range);
-#endif
 
   protected:
     virtual int set_value (const int n);
@@ -215,13 +196,6 @@ public SCLP23_NAME(Enum)  {
 //    operator Logical () const;
     SCLP23_NAME(LOGICAL) operator==( const SCLP23_NAME(LOGICAL)& t ) const;
 
-#ifdef __OSTORE__
-    static os_typespec* get_os_typespec();
-    virtual void Access_hook_in(void *object, 
-	enum os_access_reason reason, void *user_data, 
-	void *start_range, void *end_range);
-#endif
-
 }
 ;
 
@@ -231,23 +205,5 @@ public SCLP23_NAME(Enum)  {
   static const SCLP23_NAME(LOGICAL) SCLP23_NAME(UNKNOWN);
 
 //}; // end struct P23_NAMESPACE
-
-#if 0
-// *********** NOTE ****************
-// These are now defined in sdai.h
-
-#ifdef __OSTORE__
-SCLP23(BOOLEAN) *create_BOOLEAN(os_database *db);
-#else
-inline SCLP23(BOOLEAN) *create_BOOLEAN() { return new SCLP23(BOOLEAN) ; }
-#endif
-
-#ifdef __OSTORE__
-SCLP23(LOGICAL) *create_LOGICAL(os_database *db);
-#else
-inline SCLP23(LOGICAL) *create_LOGICAL() { return new SCLP23(LOGICAL) ; }
-#endif
-
-#endif
 
 #endif 

--- a/src/clstepcore/sdaiSelect.cc
+++ b/src/clstepcore/sdaiSelect.cc
@@ -32,12 +32,6 @@ SCLP23(Select)::SCLP23_NAME(Select) (const SelectTypeDescriptor *s,
 			const TypeDescriptor *td) 
 	: _type (s), underlying_type (td)
 {
-#ifdef __OSTORE__
-    if(td)
-      underlying_type_name = td->Name();
-    else
-      underlying_type_name.set_null();
-#endif
 #ifdef SCL_LOGGING
     *logStream << "Exiting SCLP23(Select) constructor." << endl;
 #endif
@@ -146,11 +140,7 @@ SCLP23(Select)::IsUnique (const BASE_TYPE bt) const
 
 SCLP23(String) SCLP23(Select)::UnderlyingTypeName () const  
 {
-#ifdef __OSTORE__
-  return underlying_type_name.chars();
-#else
   return underlying_type -> Name ();
-#endif
 }
 
 const TypeDescriptor *  SCLP23(Select)::CurrentUnderlyingType() const 
@@ -165,9 +155,6 @@ SCLP23(Select)::SetUnderlyingType (const TypeDescriptor * td)
   if (!td || !(_type -> CanBe (td))) return 0;
 
   base_type = td -> NonRefType ();
-#ifdef __OSTORE__
-  underlying_type_name = td->Name();
-#endif
 
   return underlying_type = td;
 }
@@ -182,9 +169,6 @@ bool SCLP23(Select)::exists() const
 void SCLP23(Select)::nullify() 
 {
   underlying_type = 0;
-#ifdef __OSTORE__
-  underlying_type_name.set_null();
-#endif
 }
 
 Severity 

--- a/src/clstepcore/sdaiSelect.h
+++ b/src/clstepcore/sdaiSelect.h
@@ -44,15 +44,6 @@ class SCLP23_NAME(Select) {
         const TypeDescriptor *      underlying_type;
 	BASE_TYPE 		    base_type; // used by the subtypes
 
-#ifdef __OSTORE__
-	// This member is used in the access_hook function generated for 
-	// SCLP23_NAME(Select) subtypes. It can be saved by ObjectStore where 
-	// underlying_type cannot be since it is pointing to a transient 
-	// TypeDescriptor. This is used to reinitialize underlying_type 
-	// in the access hook function.
-	SCLP23_NAME(String) underlying_type_name;
-#endif
-
 	// it looks like this member, val, is not used anywhere 9/27/96 - DAS
 	SCLP23_NAME(String) val;
 	ErrorDescriptor _error;
@@ -126,9 +117,6 @@ class SCLP23_NAME(Select) {
 	int set_null();
 	int is_null();
 
-#ifdef __OSTORE__
-	static os_typespec* get_os_typespec();
-#endif
 };	/** end class  **/
 
 typedef SCLP23_NAME(Select) * SCLP23_NAME(Select_ptr) ;

--- a/src/clutils/errordesc.h
+++ b/src/clutils/errordesc.h
@@ -15,10 +15,6 @@
 
 /* $Id: errordesc.h,v 3.0.1.2 1997/11/05 22:33:46 sauderd DP3.1 $  */ 
 
-#ifdef __OSTORE__
-#include <ostore/ostore.hh>    // Required to access ObjectStore Class Library
-#endif
-
 #ifdef __O3DB__
 #include <OpenOODB.h>
 #endif
@@ -128,10 +124,6 @@ class ErrorDescriptor {
     void debug_level(DebugLevel d)   { _debug_level = d; }
     void SetOutput(ostream *o)      { _out = o; }
 
-#ifdef __OSTORE__
-    static os_typespec* get_os_typespec();
-#endif
-    
     // void operator =  (const char* y)  {  SCLstring::operator = (y);  }
     
 /*

--- a/src/clutils/gennode.h
+++ b/src/clutils/gennode.h
@@ -15,12 +15,6 @@
 
 /* $Id: gennode.h,v 3.0.1.3 1997/11/05 22:33:47 sauderd DP3.1 $  */ 
 
-/*
-#ifdef __OSTORE__
-#include <ostore/ostore.hh>    // Required to access ObjectStore Class Library
-#endif
-*/
-
 #ifdef __O3DB__
 #include <OpenOODB.h>
 #endif
@@ -65,11 +59,6 @@ public:
 	prev = 0;
 
     }
-/*
-#ifdef __OSTORE__
-    static os_typespec* get_os_typespec();
-#endif
-*/
 };
 
 //////////////////////////////////////////////////////////////////////////////

--- a/src/clutils/gennodearray.cc
+++ b/src/clutils/gennodearray.cc
@@ -74,7 +74,6 @@ GenNodeArray::Check (int index)
         _bufsize = (index+1) * 2;
         newbuf = new GenericNode*[_bufsize];
 
-
 	memset(newbuf, 0, _bufsize);
     memmove(newbuf, _buf, _count*sizeof(GenericNode*));
 	delete [] _buf;

--- a/src/clutils/gennodearray.h
+++ b/src/clutils/gennodearray.h
@@ -21,12 +21,6 @@
  * Copyright (c) 1990 Stanford University
  */
 
-/*
-#ifdef __OSTORE__
-#include <ostore/ostore.hh>    // Required to access ObjectStore Class Library
-#endif
-*/
-
 #ifdef __O3DB__
 #include <OpenOODB.h>
 #endif
@@ -51,11 +45,7 @@ class GenNodeArray
 {
 public:
 
-//#ifdef __OSTORE__
-//    GenNodeArray (os_database *db, int defaultSize = ARRAY_DEFAULT_SIZE);
-//#else
     GenNodeArray(int defaultSize = ARRAY_DEFAULT_SIZE);
-//#endif
     virtual ~GenNodeArray();
 
     GenericNode*& operator[](int index);
@@ -71,11 +61,6 @@ public:
     virtual void ClearEntries();
     virtual void DeleteEntries();
 
-/*
-#ifdef __OSTORE__
-    static os_typespec* get_os_typespec();
-#endif
-*/
 protected:
     virtual void Check(int index);
 

--- a/src/fedex_plus/classes.c
+++ b/src/fedex_plus/classes.c
@@ -58,8 +58,6 @@ static void printEnumCreateHdr ( FILE *, const Type );
 static void printEnumCreateBody( FILE *, const Type );
 static void printEnumAggrCrHdr ( FILE *, const Type );
 static void printEnumAggrCrBody( FILE *, const Type );
-void printAccessHookFriend( FILE *, const char * );
-void printAccessHookHdr( FILE *, const char * );
 
 /*
 Turn the string into a new string that will be printed the same as the 
@@ -2276,12 +2274,6 @@ DataMemberPrint(Entity entity, FILE* file,Schema schema)
 
     /*	print list of attributes in the protected access area 	*/
 
-    printAccessHookFriend( file, entnm );
-/*
-    fprintf(file,"\n#ifdef __OSTORE__\n");
-    fprintf (file, "  friend void %s_access_hook_in(void *, \n\tenum os_access_reason, void *, void *, void *);\n", entnm);
-    fprintf(file,"#endif\n");
-*/
     fprintf (file, "  protected:\n");
 
     attr_list = ENTITYget_attributes (entity);
@@ -2428,30 +2420,14 @@ MemberFunctionSign (Entity entity, FILE* file)
 		ENTITYget_CORBAname(entity));
 */
     }
-    fprintf(file,"\n#ifdef __OSTORE__\n");
-    fprintf (file, "\tstatic os_typespec* get_os_typespec();\n");
-    fprintf (file, "\tvirtual void Access_hook_in(void *object, \n");
-    fprintf (file, "\t\tenum os_access_reason reason, void *user_data, \n");
-    fprintf (file, "\t\tvoid *start_range, void *end_range);\n");
-    fprintf(file,"#endif\n\n");
-    
     fprintf (file, "};\n");
     if(corba_binding)
     {
 	fprintf (file, "\n// Associate IDL interface generated code with implementation object\nDEF_TIE_%d(%s)\n", ENTITYget_CORBAname(entity), entnm);
     }
 
-    /*  Print ObjectStore Access Hook function  */
-    printAccessHookHdr( file, entnm );
-/*
-    fprintf(file,"\n#ifdef __OSTORE__\n");
-    fprintf (file, "void %s_access_hook_in(void *object, \n\tenum os_access_reason reason, void *user_data, \n\tvoid *start_range, void *end_range);\n", entnm);
-    fprintf(file,"#endif\n");
-*/
     /*  print creation function for class	*/
-    fprintf(file,"\n#ifdef __OSTORE__\n");
-    fprintf (file, "SCLP23(Application_instance_ptr) \ncreate_%s(os_database *db);\n", entnm);
-    fprintf(file,"\n#elif defined(__O3DB__)\n");
+    fprintf(file,"\n#if defined(__O3DB__)\n");
     fprintf (file, "inline SCLP23(Application_instance_ptr) \ncreate_%s () {  return (SCLP23(Application_instance_ptr)) new %s ;  }\n",
 	 entnm, entnm);
     fprintf (file, "#else\n");
@@ -2879,17 +2855,6 @@ LIBstructor_print (Entity entity, FILE* file, Schema schema)
 	    if  (( ! VARget_inverse (a)) && ( ! VARis_derived (a)) )  {
 	      /*  1. create a new STEPattribute	*/
 
-	      fprintf (file,"\n#ifdef __OSTORE__\n");
-	      fprintf (file,"    "
-		       "%sa = new (os_segment::of(this), \n\t\t\t    STEPattribute::get_os_typespec()) \n\t\t\t\tSTEPattribute(*%s%d%s%s, %s &_%s);\n", 
-		       (first ? "STEPattribute *" : ""),
-		       /*  first time through declare a */
-		       ATTR_PREFIX,count, 
-		       (VARis_type_shifter(a) ? "R" : ""),
-		       attrnm, 
-		       (TYPEis_entity (t) ? "(SCLP23(Application_instance_ptr) *)" : ""),
-		       attrnm);
-	      fprintf (file,"#else\n");
 	      fprintf (file,"    "
 		       "%sa = new STEPattribute(*%s%d%s%s, %s &_%s);\n", 
 		       (first ? "STEPattribute *" : ""),
@@ -2899,7 +2864,6 @@ LIBstructor_print (Entity entity, FILE* file, Schema schema)
 		       attrnm, 
 		       (TYPEis_entity (t) ? "(SCLP23(Application_instance_ptr) *)" : ""),
 		       attrnm);
-	      fprintf (file,"#endif\n");
 	      if (first)  first = 0 ;
 	      /*  2. initialize everything to NULL (even if not optional)  */
 
@@ -2943,115 +2907,6 @@ LIBstructor_print (Entity entity, FILE* file, Schema schema)
 
     entnm = ENTITYget_classname (entity);
     fprintf (file, "%s::~%s () {  }\n", entnm, entnm);
-
-    /*  print ObjectStore Access Hook function  */
-    fprintf(file,"\n#ifdef __OSTORE__\n\n");
-
-    fprintf (file, "void \n%s::Access_hook_in(void *object, \n", entnm);
-    fprintf (file, "\t\t\t\tenum os_access_reason reason, void *user_data, \n");
-    fprintf (file, "\t\t\t\tvoid *start_range, void *end_range)\n{\n");
-    fprintf (file, "    if(debug_access_hooks)\n");
-    fprintf (file, 
-	     "        std::cout << \"%s: virtual access function.\" << std::endl;\n",
-	     entnm);
-    fprintf (file, "    %s_access_hook_in(object, reason, user_data, start_range, end_range);\n", entnm);
-    fprintf (file, "}\n\n");
-
-    fprintf (file, "void \n%s_access_hook_in(void *object, \n\tenum os_access_reason reason, void *user_data, \n\tvoid *start_range, void *end_range)\n{\n", entnm);
-
-    fprintf (file, "    if(debug_access_hooks)\n");
-    fprintf (file, "        std::cout << \"%s: non-virtual access function.\" << std::endl;\n",
-	     entnm);
-    fprintf(file, "    SCLP23(Application_instance) *sent = (SCLP23(Application_instance) *)object;\n");
-    fprintf (file, "    if(debug_access_hooks)\n");
-    fprintf (file, "        std::cout << \"STEPfile_id: \" << sent->STEPfile_id << std::endl;\n");
-    fprintf(file, "    %s *ent = (%s *)sent;\n", entnm, entnm);
-    fprintf(file, "//    %s *ent = (%s *)object;\n", entnm, entnm);
-    fprintf(file, "    if(ent->eDesc == 0)\n");
-    fprintf(file, "        ent->eDesc = %s%s%s;\n",
-	    SCHEMAget_name(schema),ENT_PREFIX,ENTITYget_name(entity));
-
-    count = attr_count;
-    attr_list = ENTITYget_attributes (entity);
-    index = get_attribute_number (entity);
-
-    LISTdo (attr_list, a, Variable)
-      /*  if the attribute is Explicit, assign the Descriptor  */
-      generate_attribute_name( a, attrnm );
-      if  (( ! VARget_inverse (a)) && ( ! VARis_derived (a)) )  {
-	/*  1. assign the Descriptor for the STEPattributes	*/
-	fprintf (file,"    ent->attributes[%d].aDesc = %s%d%s%s;\n",
-		 index,
-		 ATTR_PREFIX,count, 
-		 (VARis_type_shifter(a) ? "R" : ""),
-		 attrnm);
-      }
-      if (VARget_initializer (a) == EXPRESSION_NULL) 
-      {
-	  if (TYPEis_entity (VARget_type (a)))
-	    fprintf(file, "    if(ent->_%s == 0) \n        ent->_%s = S_ENTITY_NULL;\n", attrnm, attrnm);
-      }
-      index++,
-      count++;
-    LISTod;
-    if(print_logging)
-    {
-	fprintf(file, "#ifdef SCL_LOGGING\n");
-	fprintf(file,"    if( *logStream )\n    {\n");
-	    fprintf (file, "\tlogStream->open(SCLLOGFILE,ios::app);\n");
-	fprintf(file, "\t*logStream << time(NULL) << \" SDAI %s #\" << ent->STEPfile_id \n\t    << \" accessed.\" << std::endl;\n",
-		entnm);
-	fprintf (file, "\tlogStream->close();\n");
-	fprintf(file,"    }\n");
-
-	fprintf(file, "#endif\n");
-    }
-
-    fprintf(file,"}\n");
-
-    if(corba_binding)
-    {
-
-      fprintf (file, 
-	       "\n//%d_ptr \nIDL_Application_instance_ptr \n%s::create_TIE()\n{\n", 
-	       ENTITYget_CORBAname(entity), entnm);
-/*
-      fprintf (file, 
-	       "\n//%s_ptr \nP26::Application_instance_ptr \n%s::create_TIE()\n{\n", 
-	       ENTITYget_CORBAname(entity), entnm);
-*/
-      fprintf (file, "    char markerName[16];\n");
-      fprintf (file, "    sprintf(markerName, \"%%d\", StepFileId());\n");
-      fprintf (file,
-	       "    std::cout << \"Server creating entity: \" << markerName ");
-      fprintf (file,
-	       "<< \" TIE object.\" << std::endl;\n");
-      fprintf (file, "    return new TIE_%d(%s) (this, markerName);\n",
-	       ENTITYget_CORBAname(entity), entnm);
-      fprintf (file, "}\n");
-
-    }
-
-    fprintf (file, "\nSCLP23(Application_instance_ptr) \ncreate_%s(os_database *db) \n{\n", 
-	     entnm);
-    fprintf (file, "    if(db)\n    {\n");
-    fprintf (file, 
-	     "        SCLP23(DAObject_ptr) ap = new (db, %s::get_os_typespec()) \n", 
-	     entnm);
-    fprintf (file, 
-	     "                                   %s;\n", entnm);
-    fprintf (file, "        return (SCLP23(Application_instance_ptr)) ap;\n");
-    fprintf (file, 
-	     "//        return (SCLP23(Application_instance_ptr)) new (db, %s::get_os_typespec()) \n", 
-	     entnm);
-    fprintf (file, 
-	     "//                                   %s;\n", entnm);
-    fprintf (file, "    }\n");
-    fprintf (file, "    else\n");
-    fprintf (file, 
-	     "        return (SCLP23(Application_instance_ptr)) new %s; \n}\n", 
-	     entnm);
-    fprintf(file,"#endif\n");
 
     /*  Open OODB reInit function  */
     fprintf(file,"\n#ifdef __O3DB__\n");
@@ -3223,18 +3078,6 @@ LIBstructor_print_w_args (Entity entity, FILE* file, Schema schema)
 	    if  (( ! VARget_inverse (a)) && ( ! VARis_derived (a)) )  {
 	      /*  1. create a new STEPattribute	*/
 
-	      fprintf (file,"\n#ifdef __OSTORE__\n");
-	      fprintf (file,"    "
-		       "%sa = new (os_segment::of(this), \n\t\t\t    STEPattribute::get_os_typespec()) \n\t\t\t\tSTEPattribute(*%s%d%s%s, %s &_%s);\n", 
-		       (first ? "STEPattribute *" : ""),
-		       /*  first time through declare a */
-		       ATTR_PREFIX,count, 
-		       (VARis_type_shifter(a) ? "R" : ""),
-		       attrnm, 
-		       (TYPEis_entity (t) ? "(SCLP23(Application_instance_ptr) *)" : ""),
-		       attrnm);
-	      fprintf (file,"#else\n");
-	     
 	      fprintf (file,"    "
 		       "%sa = new STEPattribute(*%s%d%s%s, %s &_%s);\n", 
 		       (first ? "STEPattribute *" : ""),
@@ -3244,7 +3087,6 @@ LIBstructor_print_w_args (Entity entity, FILE* file, Schema schema)
 		       attrnm, 
 		       (TYPEis_entity (t) ? "(SCLP23(Application_instance_ptr) *)" : ""),
 		       attrnm);
-	      fprintf (file,"#endif\n");
 
 	      if (first)  first = 0 ;
 	      /*  2. initialize everything to NULL (even if not optional)  */
@@ -3852,15 +3694,7 @@ MODELPrintConstructorBody(Entity entity, FILES* files,Schema schema
 
   n = ENTITYget_classname (entity);
 
-  fprintf (files->lib,"#ifdef __OSTORE__\n");
-  fprintf (files->lib, "    if(db)\n");
-  fprintf (files->lib, "        eep = new (db, \n");
-  fprintf (files->lib, "              SCLP23(Entity_extent)::get_os_typespec()) SCLP23(Entity_extent);\n");
-  fprintf (files->lib, "    else\n");
   fprintf (files->lib, "        eep = new SCLP23(Entity_extent);\n");
-  fprintf (files->lib,"#else\n");
-  fprintf (files->lib, "        eep = new SCLP23(Entity_extent);\n");
-  fprintf (files->lib,"#endif\n");
 
 
   fprintf (files->lib, "    eep->definition_(%s%s%s);\n", 
@@ -4233,7 +4067,6 @@ TYPEenum_inc_print (const Type type, FILE* inc)
 	n = TYPEget_ctype (type);
 	fprintf (inc, "\nclass %s  :  public SCLP23(Enum)  {\n", n);
 
-	printAccessHookFriend( inc, n );
 	fprintf (inc, "  protected:\n\tEnumTypeDescriptor *type;\n\n");
 
 	/*	constructors	*/
@@ -4266,13 +4099,6 @@ TYPEenum_inc_print (const Type type, FILE* inc)
 /*	fprintf (inc, "  private:\n\tvoid Init ();\n");*/
 	fprintf (inc, "\tvirtual const char * element_at (int n) const;\n"); 
 
-	fprintf (inc,"\n#ifdef __OSTORE__\n");
-	fprintf (inc,"\tstatic os_typespec* get_os_typespec();\n");
-	fprintf (inc, "\tvirtual void Access_hook_in(void *object, \n");
-	fprintf (inc, "\t\tenum os_access_reason reason, void *user_data, \n");
-	fprintf (inc, "\t\tvoid *start_range, void *end_range);\n");
-	fprintf (inc,"#endif\n");
-
 	/*  end class definition  */
 	fprintf (inc, "};\n");
 
@@ -4281,12 +4107,6 @@ TYPEenum_inc_print (const Type type, FILE* inc)
 
 
     /*  Print ObjectStore Access Hook function  */
-	printAccessHookHdr( inc, n );
-/*
-    fprintf(inc,"\n#ifdef __OSTORE__\n");
-    fprintf (inc, "void %s_access_hook_in(void *object, \n\tenum os_access_reason reason, void *user_data, \n\tvoid *start_range, void *end_range);\n", n);
-    fprintf(inc,"#endif\n");
-*/
 	printEnumCreateHdr( inc, type );
 
 	/* DAS brandnew above */
@@ -4296,7 +4116,6 @@ TYPEenum_inc_print (const Type type, FILE* inc)
 	
 	fprintf (inc, "\nclass %ss  :  public EnumAggregate  {\n", n);
 
-	printAccessHookFriend( inc, enumAggrNm );
 /*      fprintf (inc, "  public:\n\tvirtual EnumNode * NewNode ()  {\n");*/
 	fprintf (inc, "  protected:\n    EnumTypeDescriptor *enum_type;\n\n");
 	fprintf (inc, "  public:\n");
@@ -4306,13 +4125,8 @@ TYPEenum_inc_print (const Type type, FILE* inc)
 	fprintf (inc, "\t{ return new EnumNode (new %s( \"\", enum_type )); }"
 		      "\n", n);
 
-	fprintf(inc,"\n#ifdef __OSTORE__\n");
-	fprintf(inc, "    static os_typespec* get_os_typespec();\n");
-	fprintf(inc,"#endif\n");
-
 	fprintf (inc, "};\n");
 
-	printAccessHookHdr( inc, enumAggrNm );
 	fprintf (inc, "\ntypedef %ss * %ss_ptr;\n", n, n);
 /*
 	fprintf (inc, "typedef %ss_ptr %ss_var;\n", n, n);
@@ -4359,33 +4173,8 @@ TYPEenum_lib_print (const Type type, FILE* f)
   fprintf (f, "\n%s::%s (const char * n, EnumTypeDescriptor *et)\n"
 	      "  : type(et)\n{\n", n, n);
   fprintf (f, "  set_value (n);\n}\n");
-  
-/*NEWENUM */
-    /*  print ObjectStore Access Hook function  */
-    fprintf(f,"\n#ifdef __OSTORE__\n");
-/* ////////////// */
 
-    fprintf (f, "void \n%s::Access_hook_in(void *object, \n", n);
-    fprintf (f, "\t\t\t\tenum os_access_reason reason, void *user_data, \n");
-    fprintf (f, "\t\t\t\tvoid *start_range, void *end_range)\n{\n");
-    fprintf (f, "    if(debug_access_hooks)\n");
-    fprintf (f, 
-	     "        std::cout << \"%s: virtual access function.\" << std::endl;\n",
-	     n);
-    fprintf (f, "    %s_access_hook_in(object, reason, user_data, start_range, end_range);\n", n);
-    fprintf (f, "}\n\n");
-/* ///////////// */
-    fprintf (f, "void \n%s_access_hook_in(void *object, \n\tenum os_access_reason reason, void *user_data, \n\tvoid *start_range, void *end_range)\n{\n", n);
-
-    fprintf(f, "    %s *e = (%s *)object;\n", n, n);
-    fprintf(f, "    if(e->type == 0)\n");
-    fprintf(f, "        e->type = %s;\n", TYPEtd_name(type));
-    fprintf(f, "}\n");
-    fprintf(f,"\n#endif\n");
-/*NEWENUM */
-
-
-	/*      cast operator to an enumerated type  */
+  /*      cast operator to an enumerated type  */
   fprintf (f, "\n%s::operator %s () const {\n", n, 
 	   EnumName(TYPEget_name (type)));
   fprintf (f, "  switch (v) {\n");
@@ -4410,16 +4199,6 @@ TYPEenum_lib_print (const Type type, FILE* f)
   fprintf (f, "\n%ss::%ss( EnumTypeDescriptor *et )\n", n, n);
   fprintf (f, "    : enum_type(et)\n{\n}\n\n");
   fprintf (f, "%ss::~%ss()\n{\n}\n", n, n);
-
-    /*  print ObjectStore Access Hook function  */
-    fprintf(f,"\n#ifdef __OSTORE__\n");
-    fprintf (f, "void \n%ss_access_hook_in(void *object, \n\tenum os_access_reason reason, void *user_data, \n\tvoid *start_range, void *end_range)\n{\n", n);
-
-    fprintf(f, "    %ss *e = (%ss *)object;\n", n, n);
-    fprintf(f, "    if(e->enum_type == 0)\n");
-    fprintf(f, "        e->enum_type = %s;\n", TYPEtd_name(type));
-    fprintf(f, "}\n");
-    fprintf(f,"\n#endif\n");
 
   printEnumAggrCrBody( f, type );
 
@@ -4819,24 +4598,12 @@ TYPEprint_descriptions (const Type type, FILES* files, Schema schema)
     if(isAggregateType(type)) {
       const char * ctype = TYPEget_ctype (type);
 
-      fprintf(files->inc, "\n#ifdef __OSTORE__\n");
-      fprintf(files->inc, "STEPaggregate * create_%s (os_database *db);\n\n", 
-	      ClassName(TYPEget_name(type)));
-      fprintf(files->inc, "#else\n");
       fprintf(files->inc, "STEPaggregate * create_%s ();\n\n", 
 	      ClassName(TYPEget_name(type)));
-      fprintf(files->inc, "#endif\n");
 
-      fprintf(files->lib, "\n#ifdef __OSTORE__\n");
-      fprintf(files->lib, 
-	      "STEPaggregate *\ncreate_%s (os_database *db) { "
-	      "return create_%s(db);  }\n",
-	      ClassName(TYPEget_name(type)), ctype);
-      fprintf(files->lib, "#else\n");
       fprintf(files->lib, 
 	      "STEPaggregate *\ncreate_%s () {  return create_%s();  }\n",
 	      ClassName(TYPEget_name(type)), ctype);
-      fprintf(files->lib, "#endif\n");
 
       /* this function is assigned to the aggrCreator var in TYPEprint_new */
     }
@@ -4880,23 +4647,6 @@ TYPEprint_descriptions (const Type type, FILES* files, Schema schema)
     }
 }
 
-    /*  Print ObjectStore Access Hook function friend definition  */
-void
-printAccessHookFriend( FILE *f, const char *nm )
-{
-    fprintf(f,"\n#ifdef __OSTORE__\n");
-    fprintf (f, "  friend void %s_access_hook_in(void *, \n\tenum os_access_reason, void *, void *, void *);\n", nm);
-    fprintf(f,"#endif\n");
-}
-
-    /*  Print ObjectStore Access Hook function  */
-void
-printAccessHookHdr( FILE *f, const char *nm )
-{
-    fprintf(f,"\n#ifdef __OSTORE__\n");
-    fprintf (f, "void %s_access_hook_in(void *object, \n\tenum os_access_reason reason, void *user_data, \n\tvoid *start_range, void *end_range);\n", nm);
-    fprintf(f,"#endif\n");
-}
 
 static void
 printEnumCreateHdr( FILE *inc, const Type type )
@@ -4908,11 +4658,7 @@ printEnumCreateHdr( FILE *inc, const Type type )
 {
     const char *nm = TYPEget_ctype (type);
 
-    fprintf (inc, "\n#ifdef __OSTORE__\n");
-    fprintf (inc, "  SCLP23(Enum) * create_%s (os_database *db);\n", nm);
-    fprintf (inc, "#else\n");
     fprintf (inc, "  SCLP23(Enum) * create_%s ();\n", nm);
-    fprintf (inc, "#endif\n");
 }
 
 static void
@@ -4926,16 +4672,8 @@ printEnumCreateBody( FILE *lib, const Type type )
 
     strncpy (tdnm, TYPEtd_name(type), BUFSIZ);
 
-    fprintf (lib, "\n#ifdef __OSTORE__\n");
-    fprintf (lib, "\nSCLP23(Enum) * \ncreate_%s (os_database *db)\n{\n", nm);
-    fprintf (lib, "    if(db)\n");
-    fprintf (lib, "        return new (db, \n");
-    fprintf (lib, "                    %s::get_os_typespec()) %s;\n", nm, nm);
-    fprintf (lib, "    else\n");
-    fprintf (lib, "        return new %s( \"\", %s );\n}\n\n", nm, tdnm);
-    fprintf (lib, "#else\n");
     fprintf (lib, "\nSCLP23(Enum) * \ncreate_%s () \n{\n", nm );
-    fprintf (lib, "    return new %s( \"\", %s );\n}\n#endif\n\n", nm, tdnm );
+    fprintf (lib, "    return new %s( \"\", %s );\n}\n\n", nm, tdnm );
 }
 
 static void
@@ -4947,11 +4685,7 @@ printEnumAggrCrHdr( FILE *inc, const Type type )
     const char *n = TYPEget_ctype (type);
 /*    const char *n = ClassName( TYPEget_name(type) ));*/
 
-    fprintf (inc, "\n#ifdef __OSTORE__\n");
-    fprintf (inc, "  STEPaggregate * create_%ss (os_database *db);\n", n);
-    fprintf (inc, "#else\n");
     fprintf (inc, "  STEPaggregate * create_%ss ();\n", n);
-    fprintf (inc, "#endif\n");
 }
 
 static void
@@ -4962,16 +4696,8 @@ printEnumAggrCrBody( FILE *lib, const Type type )
 
     strncpy (tdnm, TYPEtd_name(type), BUFSIZ);
 
-    fprintf (lib,"\n#ifdef __OSTORE__\n");
-    fprintf (lib, "\nSTEPaggregate * \ncreate_%ss (os_database *db) \n{\n", n);
-    fprintf (lib, "    if(db)\n");
-    fprintf (lib, "        return new (db, \n");
-    fprintf (lib, "                    %ss::get_os_typespec()) %ss;\n", n, n);
-    fprintf (lib, "    else\n");
-    fprintf (lib, "        return new %ss( %s );\n}\n\n", n, tdnm);
-    fprintf (lib,"#else\n");
     fprintf (lib, "\nSTEPaggregate * \ncreate_%ss ()\n{\n", n);
-    fprintf (lib, "    return new %ss( %s );\n}\n#endif\n", n, tdnm);
+    fprintf (lib, "    return new %ss( %s );\n}\n", n, tdnm);
 }
 
 void
@@ -5081,24 +4807,12 @@ TYPEprint_nm_ft_desc (Schema schema, const Type type, FILE* f, char *endChars)
 		case bag_:
 		case set_:
 		case list_:
-		    fprintf(files->inc, "\n#ifdef __OSTORE__\n");
-		    fprintf(files->inc, "STEPaggregate * create_%s (os_database *db);\n\n", 
-			    ClassName(TYPEget_name(type)));
-		    fprintf(files->inc, "#else\n");
 		    fprintf(files->inc, "STEPaggregate * create_%s ();\n\n", 
 			    ClassName(TYPEget_name(type)));
-		    fprintf(files->inc, "#endif\n");
-		    fprintf(files->lib, "\n#ifdef __OSTORE__\n");
-		    fprintf(files->lib, 
-		   "STEPaggregate *\ncreate_%s (os_database *db) {  return create_%s(db);  }\n",
-			ClassName(TYPEget_name(type)), 
-			TYPEget_ctype(TYPEget_head(type)));
-		    fprintf(files->lib, "#else\n");
 		    fprintf(files->lib, 
 		   "STEPaggregate *\ncreate_%s () {  return create_%s();  }\n",
 			ClassName(TYPEget_name(type)), 
 			TYPEget_ctype(TYPEget_head(type)));
-		    fprintf(files->lib, "#endif\n");
 		    break;
 	    }
 	} else if (streq("",TYPEget_name(type))) {

--- a/src/fedex_plus/classes_wrapper.cc
+++ b/src/fedex_plus/classes_wrapper.cc
@@ -105,10 +105,6 @@ print_file_header(Express express, FILES* files)
     fprintf (files->incall, "#include <sys/time.h>\n");
     fprintf (files->incall, "#endif\n");
 
-    fprintf(files->incall,"\n#ifdef __OSTORE__\n");
-    fprintf(files->incall,"#include <ostore/ostore.hh>    // Required"
-	                  " to access ObjectStore Class Library\n");
-    fprintf(files->incall,"#endif\n\n");
     fprintf (files->incall,"#ifdef __O3DB__\n");
     fprintf (files->incall,"#include <OpenOODB.h>\n");
     fprintf (files->incall,"#endif\n\n");
@@ -342,42 +338,17 @@ SCOPEPrint( Scope scope, FILES *files, Schema schema, Express model,
 	           "\nclass SdaiModel_contents_%s : public SCLP23(Model_contents) {\n", 
 	           SCHEMAget_name(schema));
         fprintf (files -> inc, "\n  public:\n");
-	fprintf (files->inc,"\n#ifdef __OSTORE__\n");
-        fprintf (files -> inc, "    SdaiModel_contents_%s(os_database *db=0);\n", 
-	           SCHEMAget_name(schema));
-	fprintf (files->inc,"#else\n");
         fprintf (files -> inc, "    SdaiModel_contents_%s();\n", 
 	           SCHEMAget_name(schema));
-	fprintf (files->inc,"#endif\n");
         LISTdo (list, e, Entity);
 	    MODELprint_new(e, files, schema);
         LISTod;
-
-	fprintf (files->inc,"\n#ifdef __OSTORE__\n");
-	fprintf (files->inc,"\tstatic os_typespec* get_os_typespec();\n");
-	fprintf (files->inc,"#endif\n");
 
         fprintf (files->inc, "\n};\n"); 
 
         fprintf (files->inc, "\n\ntypedef SdaiModel_contents_%s * SdaiModel_contents_%s_ptr;\n", SCHEMAget_name(schema), SCHEMAget_name(schema)); 
         fprintf (files->inc, "typedef SdaiModel_contents_%s_ptr SdaiModel_contents_%s_var;\n", SCHEMAget_name(schema), SCHEMAget_name(schema)); 
 
-	fprintf (files->inc,"\n#ifdef __OSTORE__\n");
-	fprintf (files->lib,"\n#ifdef __OSTORE__\n");
-        fprintf (files -> inc,
-		 "SCLP23(Model_contents_ptr) create_SdaiModel_contents_%s(os_database *db);\n", 
-		 SCHEMAget_name(schema));
-	fprintf (files -> lib,
-		 "SCLP23(Model_contents_ptr) create_SdaiModel_contents_%s(os_database *db)\n",
-		 SCHEMAget_name(schema));
-        fprintf (files -> lib, "{\n    if(db)\n\treturn (SCLP23(Model_contents_ptr)) new (db, SdaiModel_contents_%s::get_os_typespec()) \n\t\t\tSdaiModel_contents_%s(db);\n",
-		 SCHEMAget_name(schema),
-		 SCHEMAget_name(schema));
-        fprintf (files -> lib, 
-		 "    else{\n\treturn (SCLP23(Model_contents_ptr)) new SdaiModel_contents_%s(0);\n    }\n}\n",
-		 SCHEMAget_name(schema));
-	fprintf (files->inc,"#else\n");
-	fprintf (files->lib,"#else\n");
         fprintf (files -> inc,
 		 "SCLP23(Model_contents_ptr) create_SdaiModel_contents_%s();\n", 
 		 SCHEMAget_name(schema));
@@ -386,16 +357,9 @@ SCOPEPrint( Scope scope, FILES *files, Schema schema, Express model,
 		 SCHEMAget_name(schema));
         fprintf (files -> lib, "{ return new SdaiModel_contents_%s ; }\n",
 		 SCHEMAget_name(schema));
-	fprintf (files->inc,"#endif\n\n");
-	fprintf (files->lib,"#endif\n\n");
 
-	fprintf (files->lib,"\n#ifdef __OSTORE__");
-	fprintf (files -> lib, "\nSdaiModel_contents_%s::SdaiModel_contents_%s(os_database *db)\n", 
-		 SCHEMAget_name(schema), SCHEMAget_name(schema) );
-	fprintf (files->lib,"#else");
 	fprintf (files -> lib, "\nSdaiModel_contents_%s::SdaiModel_contents_%s()\n", 
 		 SCHEMAget_name(schema), SCHEMAget_name(schema) );
-	fprintf (files->lib,"#endif\n");
 	fprintf (files -> lib, 
 		 "{\n    SCLP23(Entity_extent_ptr) eep = (SCLP23(Entity_extent_ptr))0;\n\n");
 	LISTdo (list, e, Entity);
@@ -607,12 +571,6 @@ SCHEMAprint( Schema schema, FILES *files, Express model, void *complexCol,
     if (! (incfile = (files -> inc) = FILEcreate (fnm)))  return;
     fprintf (incfile, "/* %cId$  */\n",'\044');
 
-    fprintf (incfile,"\n#ifdef __OSTORE__\n");
-    fprintf (incfile,"#include <ostore/ostore.hh>    // Required"
-	             " to access ObjectStore Class Library\n");
-/*    fprintf (incfile,"#include <osdb_%s>\n", fnm);*/
-    fprintf (incfile,"#endif\n\n");
-
     fprintf (incfile,"#ifdef __O3DB__\n");
     fprintf (incfile,"#include <OpenOODB.h>\n");
     fprintf (incfile,"#endif\n\n");
@@ -798,9 +756,6 @@ SCHEMAprint( Schema schema, FILES *files, Express model, void *complexCol,
     fprintf (schemafile, "#include <%s.h> \n",sufnm);
     if ( schema->search_id == PROCESSED ) {
 	fprintf (schemafile, "extern void %sInit (Registry & r);\n", schnm);
-	fprintf (schemafile,"\n#ifdef __OSTORE__\n");
-	fprintf (schemafile, "#include <osdb_%s.h> \n",schnm);
-	fprintf (schemafile,"#endif\n\n");
 	fprintf (schemainit, "\t extern void %sInit (Registry & r);\n", schnm);
 	fprintf (schemainit, "\t %sInit (reg); \n",schnm);
     }
@@ -923,11 +878,6 @@ EXPRESSPrint(Express express, ComplexCollect &col, FILES* files)
     if (! (incfile = (files -> inc) = FILEcreate (fnm)))  return;
     fprintf (incfile, "/* %cId$ */\n",'$');
 
-    fprintf (incfile,"\n#ifdef __OSTORE__\n");
-    fprintf (incfile,"#include <ostore/ostore.hh>    // Required"
-	             " to access ObjectStore Class Library\n");
-    fprintf (incfile,"#endif\n\n");
-
     fprintf (incfile,"#ifdef __O3DB__\n");
     fprintf (incfile,"#include <OpenOODB.h>\n");
     fprintf (incfile,"#endif\n\n");
@@ -961,10 +911,6 @@ EXPRESSPrint(Express express, ComplexCollect &col, FILES* files)
     /*  add to schema's include and initialization file	*/
     fprintf (schemafile, "#include <%s.h>\n\n", schnm);
     fprintf (schemafile, "extern void %sInit (Registry & r);\n", schnm);
-    fprintf (schemafile,"\n#ifdef __OSTORE__\n");
-    fprintf (schemafile, "#include <osdb_%s.h> \n",schnm);
-    fprintf (schemafile,"#endif\n\n");
-
     fprintf (schemainit, "\t extern void %sInit (Registry & r);\n", schnm);
     fprintf (schemainit, "\t %sInit (reg);\n", schnm);
 

--- a/src/fedex_plus/selects.c
+++ b/src/fedex_plus/selects.c
@@ -576,12 +576,6 @@ TYPEselect_inc_print_vars( const Type type, FILE *f, Linked_List dups)
    fprintf( f, "  /* unnamed union of select items */\n" );
 
    fprintf (f, "\n  public:\n");
-   fprintf (f, "\n#ifdef __OSTORE__\n");
-   fprintf (f, "\tfriend void %s_access_hook_in(void *, \n\t\t\t\t"
-	       "enum os_access_reason, void *, void *, void *);\n", classnm);
-   fprintf (f, "\tstatic os_typespec* get_os_typespec();\n");
-   fprintf (f, "#endif\n\n");
- 
    fprintf (f, 
 	   "\tvirtual const TypeDescriptor * AssignEntity (SCLP23(Application_instance) * se);\n"
 	   "\tvirtual SCLP23(Select) * NewSelect ();\n"
@@ -733,17 +727,7 @@ TYPEselect_inc_print (const Type type, FILE* f)
 
   fprintf( f, "};\n");
 
-        /* Print ObjectStore Access Hook function */
-  fprintf (f, "\n#ifdef __OSTORE__\n");
-  fprintf (f, "void %s_access_hook_in(void *object, \n\tenum os_access"
-	      "_reason reason, void *user_data, \n\tvoid *start_range, "
-	      "void *end_range);\n\n", n);
-
-	/* DAS creation function select class */
-  fprintf (f, "SCLP23(Select) * create_%s (os_database *db);\n", n, n);
-  fprintf (f, "#else\n");
   fprintf (f, "\ninline SCLP23(Select) * create_%s () { return new %s; }\n", n, n);
-  fprintf (f, "#endif\n\n");
 
         /* DAR - moved from SCOPEPrint() */
   fprintf( f, "typedef %s * %sH;\n", n, n);
@@ -756,22 +740,13 @@ TYPEselect_inc_print (const Type type, FILE* f)
   fprintf (f, "  public:\n");
   fprintf (f, "    %ss( SelectTypeDescriptor * =%s );\n", n, tdnm);
   fprintf (f, "    ~%ss();\n", n);
-  fprintf (f, "\n#ifdef __OSTORE__\n");
-  fprintf (f, "    static os_typespec* get_os_typespec();\n");
-  fprintf (f, "    virtual SingleLinkNode * NewNode();\n");
-  fprintf (f, "#else\n");
   fprintf (f, "    virtual SingleLinkNode * NewNode()\n");
   fprintf (f, "\t { return new SelectNode (new %s( sel_type )); }\n", n);
-  fprintf (f, "#endif\n");
   fprintf (f, "};\n");
 
 	/* DAS creation function for select aggregate class */
-  fprintf (f, "\n#ifdef __OSTORE__\n");
-  fprintf (f, "STEPaggregate * create_%ss (os_database *db);\n", n, n);
-  fprintf (f, "#else\n");
   fprintf (f, "inline STEPaggregate * create_%ss () { return new %ss; }\n",
 	   n, n);
-  fprintf (f, "#endif\n\n");
 
   fprintf( f, "typedef %ss_ptr %ss_var;\n", n, n );
 
@@ -796,46 +771,6 @@ TYPEselect_lib_print_part_one( const Type type, FILE* f, Schema schema,
 
   strncpy (tdnm, TYPEtd_name (type), BUFSIZ);
   strncpy (nm, SelectName( TYPEget_name(type) ), BUFSIZ);
-
-	/* DAS creation function select class */
-  fprintf (f, "\n#ifdef __OSTORE__\n");
-  fprintf (f, "SCLP23(Select) * \ncreate_%s (os_database *db) \n{\n    return "
-	      "new (db, %s::get_os_typespec()) \n\t\t%s ; \n}\n", nm, nm, nm);
-	/* generate access hook function to reinitialize SCLP23(Select)'s pointer 
-	   to the transient select dictionary entry. */
-  fprintf (f, "\nvoid \n%s_access_hook_in(void *object, \n\t\t\t\tenum "
-	      "os_access_reason reason, void *user_data, \n\t\t\t\tvoid *"
-	      "start_range, void *end_range)\n{\n", nm);
-  fprintf (f, "#ifdef SCL_LOGGING\n    if( *logStream )\n    {\n");
-  fprintf (f, "\t*logStream << \"%s access hook funct called.\" << std::endl;\n",
-	      nm);
-  fprintf (f, "    }\n#endif\n");
-/*
-  fprintf (f, "    std::cout << \"%s access hook funct called.\" << std::endl;\n",
-	   SelectName( TYPEget_name(type) ) );
-*/
-  fprintf (f, "    %s *s = (%s *) object;\n    s->_type = %s;\n", nm, nm, tdnm);
-  fprintf (f, "#ifdef SCL_LOGGING\n    if( *logStream )\n    {\n");
-  fprintf (f, "\t*logStream << \"underlying type set to \" << "
-	      "s->UnderlyingTypeName() << std::endl << std::endl;\n");
-  fprintf (f, "    }\n#endif\n");
-/*
-  fprintf (f, "    std::cout << \"underlying type set to \" << s->UnderlyingTypeName() << std::endl << std::endl;\n");
-*/
-  fprintf (f, "    const TypeDescriptor *td = s->CanBe(s->UnderlyingType"
-	      "Name());\n");
-  fprintf (f, "    s->SetUnderlyingType(td);\n");
-  fprintf (f, "    if(!td)\n");
-  fprintf (f, "\tstd::cerr << \"ERROR: can't reinitialize underlying select "
-	      "TypeDescriptor.\" \n\t     << std::endl;\n");
-  fprintf (f, "}\n");
-  fprintf (f, "#endif\n\n");
-
-	/* DAS creation function for select aggregate class */
-  fprintf (f, "\n#ifdef __OSTORE__\n");
-  fprintf (f, "STEPaggregate * \ncreate_%ss (os_database *db) \n{\n    return "
-	      "new (db, %ss::get_os_typespec()) \n\t\t%ss ; \n}\n", nm, nm, nm);
-  fprintf (f, "#endif\n\n");
 
     /*	constructor(s)	*/
 	/*  null constructor  */
@@ -946,13 +881,6 @@ TYPEselect_lib_print_part_one( const Type type, FILE* f, Schema schema,
    fprintf (f, "%ss::%ss( SelectTypeDescriptor *s)\n"
 	       "  : SelectAggregate(), sel_type(s)\n{\n}\n\n", n, n);
    fprintf (f, "%ss::~%ss() { }\n\n",n,n);
-   fprintf (f, "\n#ifdef __OSTORE__\n");
-   fprintf (f, "SingleLinkNode * \n%ss::NewNode() \n{\n",n);
-   fprintf (f, "    return new( os_segment::of(this), SelectNode::get_os"
-               "_typespec() )\n\tSelectNode( new( os_segment::of(this),\n"
-	       "\t\t\t %s::get_os_typespec() ) \n\t\t    %s );\n}\n", n,n);
-   fprintf (f, "#endif\n\n");
-
 #undef schema_name	
 }
 
@@ -1266,9 +1194,6 @@ TYPEselect_lib_print_part_four( const Type type, FILE* f, Schema schema,
 	 }
 
 	 fprintf (f, "   underlying_type = 0; // MUST BE SET BY USER\n");
-	 fprintf (f, "#ifdef __OSTORE__\n");
-	 fprintf (f, "  underlying_type_name.set_null(); \n");
-	 fprintf (f, "#endif\n");
 	 fprintf( f, "   //	discriminator = UNSET\n" );
 	 fprintf( f, "   return *this;\n}\n" );
     }
@@ -1315,9 +1240,6 @@ TYPEselect_lib_print_part_four( const Type type, FILE* f, Schema schema,
      }
    LISTod;
    fprintf( f, "   underlying_type = o -> CurrentUnderlyingType ();\n" );
-   fprintf (f, "#ifdef __OSTORE__\n");
-   fprintf (f, "   underlying_type_name = o -> UnderlyingTypeName(); \n");
-   fprintf (f, "#endif\n");
    fprintf( f, "   return *this;\n}\n\n" );
 
 /*   fprintf( f, "%s& %s::operator =( const %s& o )\n{\n", n,n,n );*/
@@ -1370,9 +1292,6 @@ TYPEselect_lib_print_part_four( const Type type, FILE* f, Schema schema,
      }
    LISTod;
    fprintf( f, "   underlying_type = o.CurrentUnderlyingType ();\n" );
-   fprintf (f, "#ifdef __OSTORE__\n");
-   fprintf (f, "   underlying_type_name = o.UnderlyingTypeName(); \n");
-   fprintf (f, "#endif\n");
    fprintf( f, "   return *this;\n}\n\n" );
    fprintf( f, "#endif\n" );
 
@@ -1395,9 +1314,6 @@ TYPEselect_lib_print_part_four( const Type type, FILE* f, Schema schema,
 		    SEL_ITEMget_dmname (t));
    LISTod;
    fprintf( f, "   underlying_type = o.CurrentUnderlyingType ();\n" );
-   fprintf (f, "#ifdef __OSTORE__\n");
-   fprintf (f, "   underlying_type_name = o.UnderlyingTypeName(); \n");
-   fprintf (f, "#endif\n");
    fprintf( f, "   return *this;\n}\n" );
 #endif
 }
@@ -1857,12 +1773,7 @@ SELlib_print_protected (const Type type,  FILE* f, const Schema schema)
   snm  = SelectName (TYPEget_name (type));
   fprintf (f, "\nSCLP23(Select) * \n%s::NewSelect ()\n{\n", snm);
 
-  fprintf (f, "#ifdef __OSTORE__\n");
-  fprintf (f, "    %s * tmp = \n\t\tnew( os_segment::of(this),\n\t\t     "
-	      "%s::get_os_typespec() ) \n\t\t\t%s();\n", snm, snm, snm);
-  fprintf (f, "#else\n");
   fprintf (f, "    %s * tmp = new %s();\n", snm, snm);
-  fprintf (f, "#endif\n");
   fprintf (f, "    return tmp;\n}\n");
 }
 
@@ -2058,21 +1969,10 @@ TYPEselect_print (Type t, FILES* files, Schema schema)
       // structor, passing the new sel's typedescriptor to create a hybrid
       // entity - the original select pointing to a new typedesc.   These fns
       // give the user an easy way to create the renamed type properly. */
-      fprintf (inc, "\n#ifdef __OSTORE__\n");
-      fprintf (inc, "void %s_access_hook_in(void *object, \n\tenum"
-	            " os_access_reason reason, void *user_data, \n"
-	            "\tvoid *start_range, void *end_range);\n\n", nm);
-      fprintf (inc, "SCLP23(Select) * create_%s (os_database *db);\n", nm, nm);
-      fprintf (inc, "#else\n");
       fprintf (inc, "inline SCLP23(Select) *\ncreate_%s ()", nm);
       fprintf (inc, " { return new %s( %s ); }\n\n", nm, tdnm);
-      fprintf (inc, "#endif\n");
-      fprintf (inc, "\n#ifdef __OSTORE__\n");
-      fprintf (inc, "STEPaggregate * create_%ss (os_database *db);\n", nm, nm);
-      fprintf (inc, "#else\n");
       fprintf (inc, "inline STEPaggregate *\ncreate_%ss ()", nm);
       fprintf (inc, " { return new %ss( %s ); }\n\n", nm, tdnm);
-      fprintf (inc, "#endif\n\n");
       return;
   }
 


### PR DESCRIPTION
eliminate all of the **OSTORE** sections.  considered dead code because there was no
managed way to enable those code sections.  appears to be a binding to a commercial
API (Progress Software Corp's ObjectStore product), so remove in favor of simplified
code maintenance and reduced complexity.  removes almost 3k lines of code.
