### PR TITLE
FLEX was being run with -l (maximal LEX compatibility)

### DIFF
--- a/src/express/CMakeLists.txt
+++ b/src/express/CMakeLists.txt
@@ -2,9 +2,9 @@ IF ("${CMAKE_BUILD_TYPE}" MATCHES "Debug")
   add_definitions( -DYYDEBUG ) #-Ddebugging
   message("Bison will create a graph of the scanner flow at ${SCL_BINARY_DIR}/expparse.dot")
   set( YACC_FLAGS "-t --graph=${SCL_BINARY_DIR}/expparse.dot" )
-  set( LEX_FLAGS "-l -d" )
+  set( LEX_FLAGS "-d" )
 ELSE()
-  set( LEX_FLAGS "-l" )
+  set( LEX_FLAGS " " )
   set( YACC_FLAGS " " ) #FindYACC.cmake insists on 3, 5, or 7 args
 ENDIF()
 
@@ -60,7 +60,7 @@ include_directories(
 )
 
 add_definitions(
-    -DHAVE_CONFIG_H
+    -DHAVE_CONFIG_H -DFLEX
 )
 
 SCL_ADDLIB(express "${EXPRESS_SOURCES}" "")


### PR DESCRIPTION
This caused NEWLINE to be defined as lineno++ (correct for normal flex operation)
when it should have been defined as nothing (because LEX increments its own line numbers)

This fixes #28.
