### PR TITLE
Fix building multiple schemas

### DIFF
--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -65,16 +65,17 @@ FUNCTION(BUILD_A_SCHEMA SCHEMA_FILE)
     message( STATUS "Generating code for ${SCHEMA_NAME}.")
     set( SCHEMA_DIR ${CMAKE_BINARY_DIR}/${SCHEMA_NAME} )
 
-    include_directories( ${CMAKE_CURRENT_SOURCE_DIR} ${SCL_SOURCE_DIR}/src/cldai
-                         ${SCL_SOURCE_DIR}/src/cleditor ${SCL_SOURCE_DIR}/src/clutils
-                         ${SCHEMA_DIR} ${SCL_SOURCE_DIR}/src/clstepcore )
-    add_definitions( -DHAVE_CONFIG_H )
-
     #the names of the files that will be generated
     set( FEDEX_OUT ${SCHEMA_DIR}/compstructs.cc ${SCHEMA_DIR}/Sdaiclasses.h 
                    ${SCHEMA_DIR}/schema.cc ${SCHEMA_DIR}/Sdai${SCHEMA_NAME}.cc
                    ${SCHEMA_DIR}/schema.h ${SCHEMA_DIR}/Sdai${SCHEMA_NAME}.h
                    ${SCHEMA_DIR}/SdaiAll.cc ${SCHEMA_DIR}/Sdai${SCHEMA_NAME}.init.cc )
+
+    # *cannot* use include_directories() because the includes keep piling up - if building
+    # multiple schemas, each one will use the include dirs from all previous schemas. Since
+    # one header (schema.h) is always named the same, this will not work. only workaround
+    # seems to be set_target_properties( <target> PROPERTIES COMPILE_FLAGS <flags> )
+    set( ${PROJECT_NAME}_COMPILE_FLAGS "-I${CMAKE_CURRENT_SOURCE_DIR} -I${SCL_SOURCE_DIR}/src/cldai -I${SCL_SOURCE_DIR}/src/cleditor -I${SCL_SOURCE_DIR}/src/clutils -I${SCHEMA_DIR} -I${SCL_SOURCE_DIR}/src/clstepcore -DHAVE_CONFIG_H" )
 
     add_custom_command( OUTPUT ${SCHEMA_DIR}
                         COMMAND cmake ARGS -E make_directory ${SCHEMA_DIR} 
@@ -87,11 +88,16 @@ FUNCTION(BUILD_A_SCHEMA SCHEMA_FILE)
                         VERBATIM )
     add_library( ${PROJECT_NAME} SHARED ${FEDEX_OUT} )
     target_link_libraries(${PROJECT_NAME} stepdai stepcore express stepeditor )
+    set_target_properties( ${PROJECT_NAME} PROPERTIES COMPILE_FLAGS
+                           ${${PROJECT_NAME}_COMPILE_FLAGS} )
     
     if( NOT DEFINED ${DISABLE_P21READ} )
         add_executable( "p21read_${PROJECT_NAME}" ${SCL_SOURCE_DIR}/src/test/p21read/p21read.cc )
         target_link_libraries( p21read_${PROJECT_NAME} ${PROJECT_NAME} )
+        set_target_properties( "p21read_${PROJECT_NAME}" PROPERTIES COMPILE_FLAGS
+                               ${${PROJECT_NAME}_COMPILE_FLAGS} )
     endif()
+
 ENDFUNCTION(BUILD_A_SCHEMA)
 
 if(NOT BUILD_SCHEMAS STREQUAL "" )


### PR DESCRIPTION
Fix puzzling build problem that cropped up - when building multiple schemas, all but first fail to build. I don't see why this wasn't a problem before.

Cause seems to be that each schema would use the include directories from all previous schemas, and would include the version of schema.h for the first schema instead of the current one.

Configured with `cmake .. -DBUILD_SCHEMAS="../data/ap214e3/AP214E3_2010.exp;../data/example/example.exp"`

make output:

<pre>
[  7%] Built target steputils
[ 28%] Built target express
[ 29%] [ 30%] Built target libexppp
Built target fedex
[ 53%] Built target stepcore
[ 54%] Built target exppp
[ 70%] Built target fedex_plus
[ 80%] Built target stepeditor
[ 87%] Built target stepdai
[ 88%] [ 94%] Built target sdai_AUTOMOTIVE_DESIGN
Building CXX object data/CMakeFiles/sdai_EXAMPLE_SCHEMA.dir/__/EXAMPLE_SCHEMA/SdaiEXAMPLE_SCHEMA.init.cc.o
[ 94%] Built target p21read_sdai_AUTOMOTIVE_DESIGN
/opt/step/dup-scl/bl/EXAMPLE_SCHEMA/SdaiEXAMPLE_SCHEMA.init.cc: In function ‘void SdaiEXAMPLE_SCHEMAInit(Registry&)’:
/opt/step/dup-scl/bl/EXAMPLE_SCHEMA/SdaiEXAMPLE_SCHEMA.init.cc:14:2: error: ‘example_schemat_length_measure’ was not declared in this scope
/opt/step/dup-scl/bl/EXAMPLE_SCHEMA/SdaiEXAMPLE_SCHEMA.init.cc:16:16: error: ‘example_schemat_color’ was not declared in this scope
/opt/step/dup-scl/bl/EXAMPLE_SCHEMA/SdaiEXAMPLE_SCHEMA.init.cc:17:2: error: ‘example_schemat_label’ was not declared in this scope
/opt/step/dup-scl/bl/EXAMPLE_SCHEMA/SdaiEXAMPLE_SCHEMA.init.cc:19:2: error: ‘example_schemat_point’ was not declared in this scope
</pre>

Part of the output of `make VERBOSE=1`:

<pre>
[ 88%] Building CXX object data/CMakeFiles/sdai_CONFIG_CONTROL_DESIGN.dir/__/CONFIG_CONTROL_DESIGN/schema.cc.o
cd /opt/step/dup-scl/bl/data && /usr/bin/c++   -Dsdai_CONFIG_CONTROL_DESIGN_EXPORTS -DHAVE_CONFIG_H -DHAVE_CONFIG_H -DHAVE_CONFIG_H -DHAVE_CONFIG_H -g -fPIC -I/opt/step/dup-scl/include -I/opt/step/dup-scl/bl/include -I/opt/step/dup-scl/data -I/opt/step/dup-scl/src/cldai -I/opt/step/dup-scl/src/cleditor -I/opt/step/dup-scl/src/clutils -I/opt/step/dup-scl/bl/AUTOMOTIVE_DESIGN -I/opt/step/dup-scl/src/clstepcore -I/opt/step/dup-scl/bl/CONFIG_CONTROL_DESIGN -I/opt/step/dup-scl/bl/IFC2X4_RC2    -Wall -o CMakeFiles/sdai_CONFIG_CONTROL_DESIGN.dir/__/CONFIG_CONTROL_DESIGN/schema.cc.o -c /opt/step/dup-scl/bl/CONFIG_CONTROL_DESIGN/schema.cc
</pre>


This is including the build dir for each schema, and apparently gcc picks the wrong version of `schema.h`.
