### PR TITLE
fix regression introduced by review/fedex-verbose

### DIFF
--- a/src/express/express.c
+++ b/src/express/express.c
@@ -74,6 +74,7 @@
 #include <stdlib.h>
 #include <setjmp.h>
 #include <errno.h>
+#include <unistd.h>
 
 #include "express/express.h"
 #include "express/resolve.h"
@@ -94,6 +95,18 @@ static Express PARSERrun PROTO( ( char *, FILE * ) );
 
 char * EXPRESSversion( void ) {
     return( "Express Language, IS (N65), October 24, 1994" );
+}
+
+int skip_exp_pause = false;
+void exp_pause() {
+    if( !skip_exp_pause ) {
+        #ifdef __WIN32__
+        getchar();
+        abort();
+        #else
+        pause();
+        #endif
+    }
 }
 
 int

--- a/src/express/expscan.l
+++ b/src/express/expscan.l
@@ -147,9 +147,9 @@ You used flex (in make_rules) but compiled with -DLEX (in Makefile)!
 
 #ifdef YYDEBUG
 extern int yydebug;
-extern int yydbg_verbose;
 extern int yydbg_upper_limit;
 extern int yydbg_lower_limit;
+int yydbg_verbose = false;
 /*
 ** Update yydebug based on yydbg_upper_limit and yydbg_lower_limit,
 ** which are set in fedex.c. They default to -1 (no effect).

--- a/src/express/fedex.c
+++ b/src/express/fedex.c
@@ -86,10 +86,10 @@ char * FEDEXversion( void ) {
 extern int yydebug;
 extern int yydbg_upper_limit;
 extern int yydbg_lower_limit;
+extern int yydbg_verbose;
 #endif /*YYDEBUG*/
 
-int skip_exp_pause = false;
-int yydbg_verbose = false;
+extern int skip_exp_pause;
 char EXPRESSgetopt_options[256] = "Bbd:e:i:w:p:u:l:nrvz";
 
 static void
@@ -118,19 +118,7 @@ usage() {
     exit( 2 );
 }
 
-void exp_pause() {
-    if( !skip_exp_pause ) {
-        #ifdef __WIN32__
-            getchar();
-            abort();
-        #else
-            pause();
-        #endif
-    }
-}
-
-int
-main( int argc, char ** argv ) {
+int main( int argc, char ** argv ) {
     int c;
     int rc;
     char * cp;


### PR DESCRIPTION
fix undefined reference to 'yydbg_verbose' and 'exp_pause'
I didn't test review/fedex-verbose as thoroughly as I thought I had
