### PR TITLE
Review/redef attrib

### DIFF
--- a/src/fedex_plus/classes.h
+++ b/src/fedex_plus/classes.h
@@ -138,6 +138,8 @@ Type TYPEget_ancestor( Type );
 /*Variable*/
 #define VARis_simple_derived(a)  (!VARis_overrider(a))
 
+Variable VARis_overrider( Entity e, Variable a );
+
 /* Added for multiple schema support: */
 void print_schemas_separate( Express, void *, FILES * );
 void getMCPrint( Express, FILE *, FILE * );

--- a/src/fedex_plus/classes_misc.c
+++ b/src/fedex_plus/classes_misc.c
@@ -286,7 +286,7 @@ TYPEget_ctype( const Type t ) {
                     strcpy (retval, ClassName (TYPEget_name (bt)));
             */
             strcpy( retval, TYPEget_ctype( bt ) );
-            strcat( retval, "s" );
+            strcat( retval, "_agg" );
             return ( retval );
         }
 

--- a/src/fedex_plus/classes_wrapper.cc
+++ b/src/fedex_plus/classes_wrapper.cc
@@ -377,9 +377,9 @@ PrintModelContentsSchema( Scope scope, FILES * files, Schema schema,
         fprintf( files->inc,
                  "typedef %s * %s_ptr;\ntypedef %s_ptr %s_var;\n\n",
                  nm, nm, nm, nm );
-        fprintf( files->inc, "class %ss;\ntypedef %ss * %ssH;\n", nm, nm, nm );
+        fprintf( files->inc, "class %s_agg;\ntypedef %s_agg * %s_aggH;\n", nm, nm, nm );
         fprintf( files->inc,
-                 "typedef %ss * %ss_ptr;\ntypedef %ss_ptr %ss_var;\n\n",
+                 "typedef %s_agg * %s_agg_ptr;\ntypedef %s_agg_ptr %s_agg_var;\n\n",
                  nm, nm, nm, nm );
     }
     SCOPEod;

--- a/src/fedex_plus/multpass.c
+++ b/src/fedex_plus/multpass.c
@@ -607,14 +607,14 @@ static void addRenameTypedefs( Schema schema, FILE * classes )
         if( TYPEis_enumeration( t ) ) {
             strncpy( nm, TYPEget_ctype( t ), BUFSIZ - 1 );
             strncpy( basenm, TYPEget_ctype( i ), BUFSIZ - 1 );
-            fprintf( classes, "typedef %ss\t%ss;\n", basenm, nm );
+            fprintf( classes, "typedef %s_agg\t%s_agg;\n", basenm, nm );
         } else {
             strncpy( nm, SelectName( TYPEget_name( t ) ), BUFSIZ - 1 );
             strncpy( basenm, SelectName( TYPEget_name( i ) ), BUFSIZ - 1 );
             fprintf( classes, "typedef %s %s;\n", basenm, nm );
             fprintf( classes, "typedef %s * %s_ptr;\n", nm, nm );
-            fprintf( classes, "typedef %ss %ss;\n", basenm, nm );
-            fprintf( classes, "typedef %ss * %ss_ptr;\n", nm, nm );
+            fprintf( classes, "typedef %s_agg %s_agg;\n", basenm, nm );
+            fprintf( classes, "typedef %s_agg * %s_agg_ptr;\n", nm, nm );
         }
     }
     SCOPEod


### PR DESCRIPTION
1. fixed #59: attributes that should be inherited in EXPRESS were not properly inherited in C++
2. fixed the error about redefinition of ‘STEPaggregate\* create_SdaiPoint_and_vector_members()’. A suffix 's' was added to the aggregate select types (suffix 's' replaced by '_agg'), which was failing on AP203e2 because of TYPE point_and_vector_member and TYPE point_and_vector_members.
