### PR TITLE
fix part of issue #74 - properly handle strings ending with S

### DIFF
--- a/src/clutils/Str.cc
+++ b/src/clutils/Str.cc
@@ -149,7 +149,7 @@ std::string ToExpressStr( istream &in, ErrorDescriptor *err ) {
             // to handle a string like 'hi'''
             if ( c == STRING_DELIM) {
                 // to handle \S\'
-                found = s.find_last_of("\\S\\");
+                found = s.rfind("\\S\\");
                 if ( !(found != string::npos && (s.size() == found + 2)) ) {
                     i_quote++;
                 }


### PR DESCRIPTION
fix part of issue #74 - find_last_of() finds any one character; replace with rfind()

For any string ending with S, the single-quote following the S was ignored. This caused
SCL to read beyond the end of the string and discard all remaining entities in the file.
std::string::find_last_of() finds any one character, rather than a specific sequence.
Replaced with std::string::rfind() for intended behavior.

The following file fails with p21read for ap203e2 if this patch is not applied, and passes if it is applied:

<pre>
ISO-10303-21;
HEADER;
FILE_DESCRIPTION(('fragment of AS1_PE_ASM'),'2;1');
FILE_NAME('TEST_STRINGS_WITH_S_AT_END','2011-10-06T',('mp'),(''),'hand edited','originally created by pro/e, 2008340','');
FILE_SCHEMA(('AP203_CONFIGURATION_CONTROLLED_3D_DESIGN_OF_MECHANICAL_PARTS_AND_ASSEMBLIES_MIM_LF'));
ENDSEC;
DATA;
#899=CARTESIAN_POINT('',(0.E0,0.E0,0.E0));
#900=DIRECTION('',(0.E0,0.E0,1.E0));
#901=DIRECTION('',(1.E0,0.E0,0.E0));
#902=AXIS2_PLACEMENT_3D('ASM_DEF_CSYS',#899,#900,#901);
ENDSEC;
END-ISO-10303-21;
</pre>
