### PR TITLE
on osx, link libs with -flat_namespace -undefined suppress

### DIFF
--- a/src/cldai/CMakeLists.txt
+++ b/src/cldai/CMakeLists.txt
@@ -29,3 +29,7 @@ include_directories(
 )
 
 SCL_ADDLIB(stepdai "${LIBSTEPDAI_SRCS}" "steputils stepcore")
+
+if(APPLE)
+    set_target_properties(stepdai PROPERTIES LINK_FLAGS "-flat_namespace -undefined suppress")
+endif(APPLE)

--- a/src/cleditor/CMakeLists.txt
+++ b/src/cleditor/CMakeLists.txt
@@ -41,3 +41,7 @@ include_directories(
 )
 
 SCL_ADDLIB(stepeditor "${LIBSTEPEDITOR_SRCS}" stepcore)
+
+if(APPLE)
+    set_target_properties(stepeditor PROPERTIES LINK_FLAGS "-flat_namespace -undefined suppress")
+endif(APPLE)

--- a/src/clutils/CMakeLists.txt
+++ b/src/clutils/CMakeLists.txt
@@ -32,6 +32,9 @@ include_directories(
 SCL_ADDLIB(steputils "${LIBSTEPUTILS_SRCS}" "")
 
 IF(MINGW)
-	TARGET_LINK_LIBRARIES(steputils shlwapi.lib)
+    TARGET_LINK_LIBRARIES(steputils shlwapi.lib)
 ENDIF(MINGW)
 
+if(APPLE)
+    set_target_properties(steputils PROPERTIES LINK_FLAGS "-flat_namespace -undefined suppress")
+endif(APPLE)

--- a/src/exppp/CMakeLists.txt
+++ b/src/exppp/CMakeLists.txt
@@ -17,3 +17,6 @@ set_target_properties(libexppp PROPERTIES PREFIX "")
 
 #SCL_ADDEXEC(exppp "${EXPPP_SOURCES}" "libexppp express")
 
+if(APPLE)
+    set_target_properties(libexppp PROPERTIES LINK_FLAGS "-flat_namespace -undefined suppress")
+endif(APPLE)


### PR DESCRIPTION
@tpaviot had [trouble](https://github.com/mpictor/StepClassLibrary/pull/85#issuecomment-2600857) with the stepeditor lib.

I decided to add the same fix for all libs that didn't have it already

If there is anyone else who has OSX, please test.
