### PR TITLE
Fix issue #72 - incorrect handling of GENERICs

### DIFF
--- a/src/express/expparse.y
+++ b/src/express/expparse.y
@@ -1405,8 +1405,10 @@ local_body        : /* no local_variables */
                 | local_variable local_body
                 ;
 
-local_decl        : TOK_LOCAL local_body TOK_END_LOCAL semicolon
-                  { }
+local_decl        : TOK_LOCAL
+                    { tag_count = 0; /* for generic_type */}
+                      local_body TOK_END_LOCAL semicolon
+                    { tag_count = -1; }
 /*                | TOK_LOCAL error TOK_END_LOCAL semicolon
                   { }*/
                 ;


### PR DESCRIPTION
Part 11 does not require a variable defined in a LOCAL to have a type label.
ap242 error: Return type or local variable requires type label in
             'validate_dependently_instantiable_entity_data_types'

This fixes issue #72 in ap242 and in a [smaller schema](https://gist.github.com/1340953#file_test_generics_type_label.exp) I created. This schema is still pretty big, or I'd put it in `test/`.

edit: I think this fixes the root problem without causing side effects. Let me know if you see any problems.
