### PR TITLE
update matrix script, change schema name in ap210e3 WIP

### DIFF
--- a/data/wip210e3/210e3_wip_v1_41_mim_lf.exp
+++ b/data/wip210e3/210e3_wip_v1_41_mim_lf.exp
@@ -5,7 +5,7 @@
 (* The schema is converted from ISO10303 P11-2003 to ISO10303 P11-1994                     *)
 (* ===================================================================================== *)
 
-SCHEMA Ap210_electronic_assembly_interconnect_and_packaging_design_mim_LF;
+SCHEMA wip210_electronic_assembly_interconnect_and_packaging_design_mim_LF;
 
 
 CONSTANT
@@ -15,7 +15,7 @@ CONSTANT
 
   dummy_gri : geometric_representation_item :=  representation_item('')||
                                    geometric_representation_item();
-  schema_prefix : STRING := 'AP210_ELECTRONIC_ASSEMBLY_INTERCONNECT_AND_PACKAGING_DESIGN_MIM_LF.';
+  schema_prefix : STRING := 'WIP210_ELECTRONIC_ASSEMBLY_INTERCONNECT_AND_PACKAGING_DESIGN_MIM_LF.';
 
   the_empty_maths_tuple      : maths_tuple := [];
 

--- a/misc/wiki-scripts/build_all.sh
+++ b/misc/wiki-scripts/build_all.sh
@@ -9,7 +9,7 @@ result_dir="."
 mk="make -j4"
 
 #separated by ; for cmake
-schemas="../data/203wseds/203wseds.exp;../data/ap203e2/ap203e2_mim_lf.exp;../data/ap210e3/ap210e3_wip1.41_mim_lf.exp;../data/ap214e3/AP214E3_2010.exp;../data/ap227/ap227.exp;../data/ap235/AP235_TC_engineering_properties_schema_20110222.exp;../data/ap240/AP240_aim_lf.exp;../data/cd209/part409cdts_wg3n2617mim_lf.exp;../data/cd242/242_n2813_mim_lf.exp;../data/ifc2x3/IFC2X3_TC1.exp;../data/ifc2x4/IFC2X4_RC3.exp;../data/ISO15926/15926-0002-lifecycle_integration.exp"
+schemas="../data/203wseds/203wseds.exp;../data/ap203e2/ap203e2_mim_lf.exp;../data/ap210e2/ap210e2_v1_40_mim_lf.exp;../data/wip210e3/210e3_wip_v1_41_mim_lf.exp;../data/ap214e3/AP214E3_2010.exp;../data/ap227/ap227.exp;../data/ap235/AP235_TC_engineering_properties_schema_20110222.exp;../data/ap240/AP240_aim_lf.exp;../data/cd209/part409cdts_wg3n2617mim_lf.exp;../data/cd242/242_n2813_mim_lf.exp;../data/ifc2x3/IFC2X3_TC1.exp;../data/ifc2x4/IFC2X4_RC3.exp;../data/ISO15926/15926-0002-lifecycle_integration.exp"
 #count warnings and errors, append to $matrix_file. creates hypertext links to stderr,stdout txt
 # $1 is the name of the row, $2 is the path and first part of the filename, $3 is the schema
 function count_we {
@@ -81,7 +81,7 @@ function build_one_schema {
     d=`echo $1|sed -e 's|^.*/\([^/]*\)\.exp$|\1|;'`
 
     echo "Running fedex_plus and gcc for $i..."
-    make generate_$d 2>"$result_dir/fedex_"$i"_stderr.txt" >"$result_dir/fedex_"$i"_stdout.txt" && \
+    make generate_cpp_$d 2>"$result_dir/fedex_"$i"_stderr.txt" >"$result_dir/fedex_"$i"_stdout.txt" && \
     $mk sdai_$d >/dev/null 2>"$result_dir/compile_libsdai_"$i"_stderr.txt" && \
     $mk p21read_sdai_$d >/dev/null 2>"$result_dir/compile_p21read_sdai_"$i"_stderr.txt"
 
@@ -131,6 +131,7 @@ function gen_wiki {
     git log --decorate=short -n1 |\
         head -n1 |\
         sed -e 's|^.*commit \([a-z0-9]\+\) .*$|### Current as of commit [\1](http://github.com/mpictor/StepClassLibrary/commit/\1)|;' >>$matrix_file
+    echo -e "\n## See also [PLIB build matrix](http://github.com/mpictor/StepClassLibrary/wiki/PLIB-build-matrix)\n\n" >>$matrix_file
     echo "<table border=1>" >>$matrix_file
     echo "<tr><th>Key</th></tr><tr><td><table width=100%>" >>$matrix_file
     echo "<tr><th>Item</th><th>Description</th></tr>" >>$matrix_file


### PR DESCRIPTION
- Update file names in schema matrix script
- Change schema name for ap210e3 WIP so that it will work alongside ap210e2 (otherwise both are built in the same directory and use the same entry in the schema matrix):

``` diff
-SCHEMA Ap210_electronic_assembly_interconnect_and_packaging_design_mim_LF;
+SCHEMA wip210_electronic_assembly_interconnect_and_packaging_design_mim_LF;
 ...
-  schema_prefix : STRING := 'AP210_ELECTRONIC_ASSEMBLY_INTERCONNECT_AND_PACKAGING_DESIGN_MIM_LF.';
+  schema_prefix : STRING := 'WIP210_ELECTRONIC_ASSEMBLY_INTERCONNECT_AND_PACKAGING_DESIGN_MIM_LF.';
```
