### PR TITLE
change scl_version_string.cmake to fix parallel ctest issue

### DIFF
--- a/cmake/scl_version_string.cmake
+++ b/cmake/scl_version_string.cmake
@@ -27,20 +27,6 @@ endif()
 
 string( REPLACE "\n" "" GIT_COMMIT_ID ${GIT_COMMIT_ID} )
 
-set( res_var 1 )
-IF (WIN32)
-    EXECUTE_PROCESS(COMMAND "date" "/T" RESULT_VARIABLE res_var OUTPUT_VARIABLE TIMESTAMP )
-ELSEIF(UNIX)
-    EXECUTE_PROCESS(COMMAND "date" RESULT_VARIABLE res_var OUTPUT_VARIABLE TIMESTAMP )
-ELSE()
-    MESSAGE(WARNING "Unknown platform: date not included in version string")
-ENDIF()
-if( NOT ${res_var} EQUAL 0 )
-    SET( TIMESTAMP "000000" )
-else()
-    string( REPLACE "\n" "" TIMESTAMP ${TIMESTAMP} )
-endif()
-
 set( vstring "//scl_version_string.h - written by cmake. Changes will be lost!\n"
              "#ifndef SCL_VERSION_STRING\n"
              "#define SCL_VERSION_STRING\n\n"
@@ -49,7 +35,7 @@ set( vstring "//scl_version_string.h - written by cmake. Changes will be lost!\n
              "** 'g' is unknown, 5e1fb47 is the first 7 chars of the git sha1 commit id, and\n"
              "** <timestamp> is the output of your system's 'date' command.\n*/\n\n"
              "const char* scl_version() {\n"
-             "    return \"git commit id ${GIT_COMMIT_ID}, built on ${TIMESTAMP}\"\;\n"
+             "    return \"git commit id ${GIT_COMMIT_ID}, built at \"__TIME__\" on \"__DATE__\;\n"
              "}\n\n"
              "#endif\n"
    )


### PR DESCRIPTION
This replaces use of the system `time` command with `__DATE__` and `__TIME__`, which the preprocessor recognizes

I think the following two errors are caused by fedex_plus being rebuilt for each test:

<pre>Linking CXX executable ../../bin/fedex_plus
CMakeFiles/fedex_plus.dir/__/express/fedex.c.o: file not recognized: File truncated</pre>


and

<pre>[ 87%] Running fedex_plus for AP214E3_2010...
/bin/sh: /opt/step/test-scl/build_ctest/bin/fedex_plus: Text file busy</pre>


`fedex_plus` is being rebuilt because the version string changes. It changes because it contains the date and time.

When running multiple tests in parallel, fedex_plus is being rebuilt in parallel in the same directory, so sometimes one instance of gcc or ld tries to use an invalid file.
