### PR TITLE
Create schema matrix using python and ctest

### DIFF
--- a/ctest_matrix.cmake
+++ b/ctest_matrix.cmake
@@ -51,3 +51,7 @@ ctest_build( BUILD "${CTEST_BINARY_DIRECTORY}" )
 message("running tests")
 ctest_test( BUILD "${CTEST_BINARY_DIRECTORY}" PARALLEL_LEVEL ${PROCESSOR_COUNT}
                         INCLUDE_LABEL "cpp_schema_....*" )
+
+message("running python script")
+execute_process( COMMAND python ../misc/wiki-scripts/update-matrix.py
+                 WORKING_DIRECTORY ${CTEST_BINARY_DIRECTORY} )


### PR DESCRIPTION
Create [schema matrix](http://github.com/mpictor/StepClassLibrary/wiki/Schema-build-matrix) using python and ctest - closes issue #99

The scripts should be future-proof - they will work with additional schemas without modification.

The python script will exit if it does not find a git repo for the wiki at `scl/../wiki-scl`, containing the file `Schema-build-matrix.md`.

Use:

``` bash
cd scl/
ctest -S ctest_matrix.cmake
```
