### PR TITLE
Fixed issue for bcc32 v6.30 and up.

### DIFF
--- a/include/scl_stdbool.h
+++ b/include/scl_stdbool.h
@@ -25,7 +25,7 @@
 /**
  * Borland C++ 5.5.1 does not define _Bool.
  */
-#ifdef __BORLANDC__
+#if defined(__BORLANDC__) && __BORLANDC__ < 0x630
 typedef int _Bool;
 #endif
 


### PR DESCRIPTION
- _Bool type is a known keyword for bcc32 v6.30 and up.
