### PR TITLE
Fixed memory leak in HASHfind() function

### DIFF
--- a/src/express/hash.c
+++ b/src/express/hash.c
@@ -314,11 +314,12 @@ HASHdestroy( Hash_Table table ) {
 void *
 HASHfind( Hash_Table t, char * s ) {
 //    Element * ep;
-    struct Element_ *ep = malloc( sizeof * ep );
+    struct Element_ *ep = NULL;
     struct Element_ *e = malloc( sizeof * e );
     e -> key = s;
     e -> symbol = 0; /*  initialize to 0 - 25-Apr-1994 - kcm */
     ep = HASHsearch( t, e, HASH_FIND );
+    free(e);
     return( ep ? ep->data : 0 );
 }
 


### PR DESCRIPTION
In hash.c, in the HASHfind() method:
- ep does not need to be allocated
- pointer e is never freed.

I ran valgrind with memcheck and tested running p21read from the cmake-build/test/bin directory:
</pre>
valgrind --tool=memcheck ./p21read_sdai_203wseds ../../data/203wseds/gasket1.p21 --dsymutil=yes
</pre>

Here are the results:

<pre>
Before the fix:
==========

==49080== HEAP SUMMARY:
==49080==     in use at exit: 1,578,899 bytes in 7,047 blocks
==49080==   total heap usage: 14,286 allocs, 7,239 frees, 1,906,351 bytes allocated
==49080== 
==49080== LEAK SUMMARY:
==49080==    definitely lost: 49,579 bytes in 1,223 blocks
==49080==    indirectly lost: 605 bytes in 13 blocks
==49080==      possibly lost: 96,528 bytes in 597 blocks
==49080==    still reachable: 1,432,099 bytes in 5,213 blocks
==49080==         suppressed: 88 bytes in 1 blocks
==49080== Rerun with --leak-check=full to see details of leaked memory
==49080== 
==49080== For counts of detected and suppressed errors, rerun with: -v
==49080== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)

After the fix:
=========

==48941== HEAP SUMMARY:
==48941==     in use at exit: 1,544,000 bytes in 6,174 blocks
==48941==   total heap usage: 13,849 allocs, 7,675 frees, 1,888,892 bytes allocated
==48941== 
==48941== LEAK SUMMARY:
==48941==    definitely lost: 14,699 bytes in 351 blocks
==48941==    indirectly lost: 605 bytes in 13 blocks
==48941==      possibly lost: 96,528 bytes in 597 blocks
==48941==    still reachable: 1,432,080 bytes in 5,212 blocks
==48941==         suppressed: 88 bytes in 1 blocks
==48941== Rerun with --leak-check=full to see details of leaked memory
==48941== 
==48941== For counts of detected and suppressed errors, rerun with: -v
==48941== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
</pre>

The `definitely lost bytes` appear to be slightly reduced. This (small) improvement needs however some additional test in order to ensure that the fix does not introduce any regression.
