### PR TITLE
Replaced strncpy with strlcpy

### DIFF
--- a/src/clprobe-ui/probe.cc
+++ b/src/clprobe-ui/probe.cc
@@ -1873,16 +1873,14 @@ void Probe::DescribeEntityCmd() {
         // abstract entities are marked with an asterisk at end of entity name
         if( entPtr[strlen( entPtr ) - 1] == '*' ) {
             char ent[512];
-            strncpy( ent, entPtr, 512 );
-            ent[strlen( entPtr ) - 1] = '\0'; // get rid of trailing * indicating
+            strlcpy( ent, entPtr, 512 );
             // it is an abstract entity type
             entPtr = ent;
         }
         // entities requiring external mapping have an '%' at the end
         else if( entPtr[strlen( entPtr ) - 1] == '%' ) {
             char ent[512];
-            strncpy( ent, entPtr, 512 );
-            ent[strlen( entPtr ) - 1] = '\0';
+            strlcpy( ent, entPtr, 512 );
             entPtr = ent;
         }
         StepEntityDescriptor * sed =

--- a/src/express/lexact.c
+++ b/src/express/lexact.c
@@ -429,7 +429,7 @@ SCANprocess_semicolon( int commentp ) {
 
 void
 SCANsave_comment( void ) {
-    strncpy( last_comment_ , yytext, 255 );
+    strlcpy( last_comment_ , yytext, 255 );
     last_comment = last_comment_;
 }
 

--- a/src/fedex_plus/classes.c
+++ b/src/fedex_plus/classes.c
@@ -101,7 +101,7 @@ void USEREFout( Schema schema, Dictionary refdict, Linked_List reflist, char * t
     char td_name[BUFSIZ];
     char sch_name[BUFSIZ];
 
-    strncpy( sch_name, PrettyTmpName( SCHEMAget_name( schema ) ), BUFSIZ );
+    strlcpy( sch_name, PrettyTmpName( SCHEMAget_name( schema ) ), BUFSIZ );
 
     LISTdo( reflist, s, Schema ) {
         fprintf( file, "        // %s FROM %s; (all objects)\n", type, s->symbol.name );
@@ -355,7 +355,7 @@ const char * TYPEget_idl_type( const Type t ) {
     /*    case TYPE_ENUM:   */
     /*    case TYPE_SELECT: */
     if( class == enumeration_ ) {
-        strncpy( retval, EnumName( TYPEget_name( t ) ), BUFSIZ - 2 );
+        strlcpy( retval, EnumName( TYPEget_name( t ) ), BUFSIZ - 2 );
 
         strcat( retval, " /*" );
         strcat( retval, IdlEntityTypeName( t ) );
@@ -423,7 +423,7 @@ char * generate_attribute_name( Variable a, char * out ) {
 
 char * generate_attribute_func_name( Variable a, char * out ) {
     generate_attribute_name( a, out );
-    strncpy( out, StrToLower( out ), BUFSIZ );
+    strlcpy( out, StrToLower( out ), BUFSIZ );
     if( old_accessors ) {
         out[0] = toupper( out[0] );
     } else {
@@ -463,7 +463,7 @@ char * generate_dict_attr_name( Variable a, char * out ) {
         p = p + 5;
     }
     /*  copy p to out  */
-    strncpy( out, StrToLower( p ), BUFSIZ );
+    strlcpy( out, StrToLower( p ), BUFSIZ );
     /* DAR - fixed so that '\n's removed */
     for( j = 0, q = out; j < BUFSIZ; p++ ) {
         /* copy p to out, 1 char at time.  Skip \n's, and convert to lc. */
@@ -600,7 +600,7 @@ void ATTRsign_access_methods( Variable a, FILE * file ) {
 
     generate_attribute_func_name( a, attrnm );
 
-    strncpy( ctype, AccessType( t ), BUFSIZ );
+    strlcpy( ctype, AccessType( t ), BUFSIZ );
     fprintf( file, "        const %s %s() const;\n", ctype, attrnm );
     fprintf( file, "        void %s (const %s x);\n\n", attrnm, ctype );
     return;
@@ -632,7 +632,7 @@ void ATTRprint_access_methods_get_head( const char * classnm, Variable a,
 
     /* ///////////////////////////////////////////////// */
 
-    strncpy( ctype, AccessType( t ), BUFSIZ );
+    strlcpy( ctype, AccessType( t ), BUFSIZ );
     fprintf( file, "\nconst %s \n%s::%s() const\n", ctype, classnm, funcnm );
     return;
 }
@@ -663,7 +663,7 @@ void ATTRprint_access_methods_put_head( CONST char * entnm, Variable a, FILE * f
 
     /* ///////////////////////////////////////////////// */
 
-    strncpy( ctype, AccessType( t ), BUFSIZ );
+    strlcpy( ctype, AccessType( t ), BUFSIZ );
     fprintf( file, "\nvoid \n%s::%s (const %s x)\n\n", entnm, funcnm, ctype );
     return;
 }
@@ -703,7 +703,7 @@ void ATTRprint_access_methods( CONST char * entnm, Variable a, FILE * file ) {
     /* I believe nm has the name of the underlying type without Sdai in
        front of it */
     if( TYPEget_name( t ) ) {
-        strncpy( nm, FirstToUpper( TYPEget_name( t ) ), BUFSIZ - 1 );
+        strlcpy( nm, FirstToUpper( TYPEget_name( t ) ), BUFSIZ - 1 );
     }
 
     generate_attribute_func_name( a, funcnm );
@@ -712,7 +712,7 @@ void ATTRprint_access_methods( CONST char * entnm, Variable a, FILE * file ) {
     strcpy( membernm, attrnm );
     membernm[0] = toupper( membernm[0] );
     class = TYPEget_type( t );
-    strncpy( ctype, AccessType( t ), BUFSIZ );
+    strlcpy( ctype, AccessType( t ), BUFSIZ );
 
     if( isAggregate( a ) ) {
         AGGRprint_access_methods( entnm, a, file, t, ctype, attrnm );
@@ -1037,7 +1037,7 @@ void ENTITYhead_print( Entity entity, FILE * file, Schema schema ) {
     int attr_count_tmp = attr_count;
     Entity super = 0;
 
-    strncpy( entnm, ENTITYget_classname( entity ), BUFSIZ );
+    strlcpy( entnm, ENTITYget_classname( entity ), BUFSIZ );
 
     fprintf( file, "\nclass %s  :  ", entnm );
 
@@ -1112,7 +1112,7 @@ void DataMemberPrintAttr( Entity entity, Variable a, FILE * file ) {
 void DataMemberPrint( Entity entity, Linked_List nonInheritedAttrList, FILE * file, Schema schema ) {
     Linked_List attr_list;
     char entnm [BUFSIZ];
-    strncpy( entnm, ENTITYget_classname( entity ), BUFSIZ ); /*  assign entnm  */
+    strlcpy( entnm, ENTITYget_classname( entity ), BUFSIZ ); /*  assign entnm  */
 
     /*  print list of attributes in the protected access area   */
     fprintf( file, "  protected:\n" );
@@ -1186,7 +1186,7 @@ void MemberFunctionSign( Entity entity, Linked_List nonInheritedAttrList, FILE *
     static int entcode = 0;
     char entnm [BUFSIZ];
 
-    strncpy( entnm, ENTITYget_classname( entity ), BUFSIZ ); /*  assign entnm  */
+    strlcpy( entnm, ENTITYget_classname( entity ), BUFSIZ ); /*  assign entnm  */
 
     fprintf( file, "  public:  \n" );
 
@@ -1278,7 +1278,7 @@ void LIBmemberFunctionPrint( Entity entity, Linked_List nonInheritedAttrList, FI
     Linked_List attr_list;
     char entnm [BUFSIZ];
 
-    strncpy( entnm, ENTITYget_classname( entity ), BUFSIZ ); /*  assign entnm */
+    strlcpy( entnm, ENTITYget_classname( entity ), BUFSIZ ); /*  assign entnm */
 
     /*  1. put in member functions which belong to all entities */
     /*  the common function are still in the class definition 17-Feb-1992 */
@@ -2596,7 +2596,7 @@ void TYPEenum_inc_print( const Type type, FILE * inc ) {
     fprintf( inc, "  protected:\n        EnumTypeDescriptor *type;\n\n" );
 
     /*  constructors    */
-    strncpy( tdnm, TYPEtd_name( type ), BUFSIZ );
+    strlcpy( tdnm, TYPEtd_name( type ), BUFSIZ );
     fprintf( inc, "  public:\n        %s (const char * n =0, Enum"
              "TypeDescriptor *et =%s);\n", n, tdnm );
     fprintf( inc, "        %s (%s e, EnumTypeDescriptor *et =%s)\n"
@@ -2675,7 +2675,7 @@ void TYPEenum_lib_print( const Type type, FILE * f ) {
     fprintf( f, "  switch (n)  {\n" );
     DICTdo_type_init( ENUM_TYPEget_items( type ), &de, OBJ_ENUM );
     while( 0 != ( expr = ( Expression )DICTdo( &de ) ) ) {
-        strncpy( c_enum_ele, EnumCElementName( type, expr ), BUFSIZ );
+        strlcpy( c_enum_ele, EnumCElementName( type, expr ), BUFSIZ );
         fprintf( f, "  case %s:  return \"%s\";\n",
                  c_enum_ele,
                  StrToUpper( EXPget_name( expr ) ) );
@@ -2695,7 +2695,7 @@ void TYPEenum_lib_print( const Type type, FILE * f ) {
     fprintf( f, "  switch (v) {\n" );
     DICTdo_type_init( ENUM_TYPEget_items( type ), &de, OBJ_ENUM );
     while( 0 != ( expr = ( Expression )DICTdo( &de ) ) ) {
-        strncpy( c_enum_ele, EnumCElementName( type, expr ), BUFSIZ );
+        strlcpy( c_enum_ele, EnumCElementName( type, expr ), BUFSIZ );
         fprintf( f, "        case %s:  ", c_enum_ele );
         fprintf( f, "return %s;\n", c_enum_ele );
 
@@ -2934,13 +2934,13 @@ void TYPEprint_typedefs( Type t, FILE * classes ) {
             // nition of another enum.  (Those are printed at the end of the
             // classes file - after all the actual enum's.  They must be
             // printed last since they depend on the others.) */
-            strncpy( nm, TYPEget_ctype( t ), BUFSIZ );
+            strlcpy( nm, TYPEget_ctype( t ), BUFSIZ );
             fprintf( classes, "class %s_agg;\n", nm );
         }
     } else if( TYPEis_select( t ) ) {
         if( !TYPEget_head( t ) ) {
             /* Same comment as above. */
-            strncpy( nm, SelectName( TYPEget_name( t ) ), BUFSIZ );
+            strlcpy( nm, SelectName( TYPEget_name( t ) ), BUFSIZ );
             fprintf( classes, "class %s;\n", nm );
             fprintf( classes, "typedef %s * %s_ptr;\n", nm, nm );
             fprintf( classes, "class %s_agg;\n", nm );
@@ -2963,7 +2963,7 @@ void TYPEprint_typedefs( Type t, FILE * classes ) {
             /* At this point, we'll print typedefs for types which are redefined
             // fundamental types and their aggregates, and for 2D aggregates(aggre-
             // gates of aggregates) of enum's and selects. */
-            strncpy( nm, ClassName( TYPEget_name( t ) ), BUFSIZ );
+            strlcpy( nm, ClassName( TYPEget_name( t ) ), BUFSIZ );
             fprintf( classes, "typedef %s         %s;\n", TYPEget_ctype( t ), nm );
             if( TYPEis_aggregate( t ) ) {
                 fprintf( classes, "typedef %s *         %sH;\n", nm, nm );
@@ -2975,7 +2975,7 @@ void TYPEprint_typedefs( Type t, FILE * classes ) {
 
     /* Print the extern statement: */
 #if !defined(__BORLAND__)
-    strncpy( nm, TYPEtd_name( t ), BUFSIZ );
+    strlcpy( nm, TYPEtd_name( t ), BUFSIZ );
     fprintf( classes, "extern %s         *%s;\n", GetTypeDescriptorName( t ), nm );
 #endif
 }
@@ -3119,7 +3119,7 @@ void TYPEprint_descriptions( const Type type, FILES * files, Schema schema ) {
          nm [BUFSIZ];
     Type i;
 
-    strncpy( tdnm, TYPEtd_name( type ), BUFSIZ );
+    strlcpy( tdnm, TYPEtd_name( type ), BUFSIZ );
 
     /* define type descriptor pointer */
     /*  put extern def in header, put the real definition in .cc file  */
@@ -3151,11 +3151,11 @@ void TYPEprint_descriptions( const Type type, FILES * files, Schema schema ) {
     if( TYPEis_enumeration( type ) && ( i = TYPEget_ancestor( type ) ) != NULL ) {
         /* If we're a renamed enum type, just print a few typedef's to the
         // original and some specialized create functions: */
-        strncpy( base, EnumName( TYPEget_name( i ) ), BUFSIZ );
-        strncpy( nm, EnumName( TYPEget_name( type ) ), BUFSIZ );
+        strlcpy( base, EnumName( TYPEget_name( i ) ), BUFSIZ );
+        strlcpy( nm, EnumName( TYPEget_name( type ) ), BUFSIZ );
         fprintf( files->inc, "typedef %s %s;\n", base, nm );
-        strncpy( base, TYPEget_ctype( i ), BUFSIZ );
-        strncpy( nm, TYPEget_ctype( type ), BUFSIZ );
+        strlcpy( base, TYPEget_ctype( i ), BUFSIZ );
+        strlcpy( nm, TYPEget_ctype( type ), BUFSIZ );
         fprintf( files->inc, "typedef %s %s;\n", base, nm );
         printEnumCreateHdr( files->inc, type );
         printEnumCreateBody( files->lib, type );
@@ -3196,7 +3196,7 @@ static void printEnumCreateBody( FILE * lib, const Type type ) {
     const char * nm = TYPEget_ctype( type );
     char tdnm[BUFSIZ];
 
-    strncpy( tdnm, TYPEtd_name( type ), BUFSIZ );
+    strlcpy( tdnm, TYPEtd_name( type ), BUFSIZ );
 
     fprintf( lib, "\nSDAI_Enum * \ncreate_%s () \n{\n", nm );
     fprintf( lib, "    return new %s( \"\", %s );\n}\n\n", nm, tdnm );
@@ -3213,7 +3213,7 @@ static void printEnumAggrCrBody( FILE * lib, const Type type ) {
     const char * n = TYPEget_ctype( type );
     char tdnm[BUFSIZ];
 
-    strncpy( tdnm, TYPEtd_name( type ), BUFSIZ );
+    strlcpy( tdnm, TYPEtd_name( type ), BUFSIZ );
 
     fprintf( lib, "\nSTEPaggregate * \ncreate_%s_agg ()\n{\n", n );
     fprintf( lib, "    return new %s_agg( %s );\n}\n", n, tdnm );
@@ -3223,7 +3223,7 @@ void TYPEprint_init( const Type type, FILE * ifile, Schema schema ) {
     char tdnm [BUFSIZ];
     char typename_buf[MAX_LEN];
 
-    strncpy( tdnm, TYPEtd_name( type ), BUFSIZ );
+    strlcpy( tdnm, TYPEtd_name( type ), BUFSIZ );
 
     if( isAggregateType( type ) ) {
         if( !TYPEget_head( type ) ) {

--- a/src/fedex_plus/classes_misc.c
+++ b/src/fedex_plus/classes_misc.c
@@ -293,7 +293,7 @@ TYPEget_ctype( const Type t ) {
 
     /*      case TYPE_ENTITY:   */
     if( class == entity_ ) {
-        strncpy( retval, TypeName( t ), BUFSIZ - 2 );
+        strlcpy( retval, TypeName( t ), BUFSIZ - 2 );
         strcat( retval, "_ptr" );
         return retval;
         /*  return ("STEPentityH");    */
@@ -301,7 +301,7 @@ TYPEget_ctype( const Type t ) {
     /*    case TYPE_ENUM:   */
     /*    case TYPE_SELECT: */
     if( class == enumeration_ ) {
-        strncpy( retval, TypeName( t ), BUFSIZ - 2 );
+        strlcpy( retval, TypeName( t ), BUFSIZ - 2 );
         strcat( retval, "_var" );
         return retval;
     }
@@ -345,12 +345,12 @@ const char *
 AccessType( Type t ) {
     Class_Of_Type class;
     static char nm [BUFSIZ];
-    strncpy( nm, TypeName( t ), BUFSIZ - 4 );
+    strlcpy( nm, TypeName( t ), BUFSIZ - 4 );
     if( TYPEis_entity( t ) ) {
         /*  if(corba_binding)
             {
                 if (TYPEget_name (t))
-                  strncpy (nm, FirstToUpper (TYPEget_name (t)), BUFSIZ-1);
+                  strlcpy (nm, FirstToUpper (TYPEget_name (t)), BUFSIZ-1);
             }
         */
         strcat( nm, "_ptr" );
@@ -361,17 +361,17 @@ AccessType( Type t ) {
     }
     class = TYPEget_type( t );
     if( class == enumeration_ ) {
-        strncpy( nm, TypeName( t ), BUFSIZ - 2 );
+        strlcpy( nm, TypeName( t ), BUFSIZ - 2 );
         strcat( nm, "_var" );
         return nm;
     }
     if( class == logical_ ) {
-        strncpy( nm, "Logical", BUFSIZ - 2 );
+        strlcpy( nm, "Logical", BUFSIZ - 2 );
     }
 
     /*    case TYPE_BOOLEAN:    */
     if( class == boolean_ ) {
-        strncpy( nm, "Boolean", BUFSIZ - 2 );
+        strlcpy( nm, "Boolean", BUFSIZ - 2 );
     }
     return nm;
 }
@@ -466,7 +466,7 @@ EnumName( const char * oldname ) {
     strcpy( newname, ENUM_PREFIX )    ;
     j = strlen( ENUM_PREFIX )    ;
     newname [j] = ToUpper( oldname [0] );
-    strncpy( newname + j + 1, StrToLower( oldname + 1 ), MAX_LEN - j - 1 );
+    strlcpy( newname + j + 1, StrToLower( oldname + 1 ), MAX_LEN - j - 1 );
     j = strlen( newname );
     newname [j] = '\0';
     return ( newname );
@@ -484,7 +484,7 @@ SelectName( const char * oldname ) {
     newname [0] = ToUpper( newname [0] );
     j = strlen( TYPE_PREFIX );
     newname [j] = ToUpper( oldname [0] );
-    strncpy( newname + j + 1, StrToLower( oldname + 1 ), MAX_LEN - j - 1 );
+    strlcpy( newname + j + 1, StrToLower( oldname + 1 ), MAX_LEN - j - 1 );
     j = strlen( newname );
     newname [j] = '\0';
     return ( newname );
@@ -494,7 +494,7 @@ const char *
 FirstToUpper( const char * word ) {
     static char newword [MAX_LEN];
 
-    strncpy( newword, word, MAX_LEN );
+    strlcpy( newword, word, MAX_LEN );
     newword[0] = ToUpper( newword[0] );
     return ( newword );
 }

--- a/src/fedex_plus/multpass.c
+++ b/src/fedex_plus/multpass.c
@@ -605,12 +605,12 @@ static void addRenameTypedefs( Schema schema, FILE * classes )
             firsttime = FALSE;
         }
         if( TYPEis_enumeration( t ) ) {
-            strncpy( nm, TYPEget_ctype( t ), BUFSIZ - 1 );
-            strncpy( basenm, TYPEget_ctype( i ), BUFSIZ - 1 );
+            strlcpy( nm, TYPEget_ctype( t ), BUFSIZ - 1 );
+            strlcpy( basenm, TYPEget_ctype( i ), BUFSIZ - 1 );
             fprintf( classes, "typedef %s_agg        %s_agg;\n", basenm, nm );
         } else {
-            strncpy( nm, SelectName( TYPEget_name( t ) ), BUFSIZ - 1 );
-            strncpy( basenm, SelectName( TYPEget_name( i ) ), BUFSIZ - 1 );
+            strlcpy( nm, SelectName( TYPEget_name( t ) ), BUFSIZ - 1 );
+            strlcpy( basenm, SelectName( TYPEget_name( i ) ), BUFSIZ - 1 );
             fprintf( classes, "typedef %s %s;\n", basenm, nm );
             fprintf( classes, "typedef %s * %s_ptr;\n", nm, nm );
             fprintf( classes, "typedef %s_agg %s_agg;\n", basenm, nm );
@@ -647,7 +647,7 @@ static void addAggrTypedefs( Schema schema, FILE * classes )
                 fprintf( classes, "mas) which depend on other types:\n" );
                 firsttime = FALSE;
             }
-            strncpy( nm, ClassName( TYPEget_name( t ) ), BUFSIZ );
+            strlcpy( nm, ClassName( TYPEget_name( t ) ), BUFSIZ );
             fprintf( classes, "typedef %s        %s;\n",
                      TYPEget_ctype( t ), nm );
             fprintf( classes, "typedef %s *        %sH;\n", nm, nm );

--- a/src/fedex_plus/selects.c
+++ b/src/fedex_plus/selects.c
@@ -159,7 +159,7 @@ utype_member( const Linked_List list, const Type check, int rename ) {
     if( TYPEis_entity( t ) && TYPEis_entity( check ) ) {
         return "SDAI_Application_instance_ptr";
     }
-    strncpy( r, TYPEget_utype( t ), BUFSIZ );
+    strlcpy( r, TYPEget_utype( t ), BUFSIZ );
     if( strcmp( r, TYPEget_utype( check ) ) == 0 ) {
         return r;
     }
@@ -308,7 +308,7 @@ duplicate_utype_member( const Linked_List list, const Type check ) {
     }
     /*  don\'t compare check to itself  */
     else {   /*  continue looking  */
-        strncpy( b, TYPEget_utype( t ), BUFSIZ );
+        strlcpy( b, TYPEget_utype( t ), BUFSIZ );
         if( ( !strcmp( b, TYPEget_utype( check ) ) )
                 || ( compareOrigTypes( t, check ) ) )
             /*  if the underlying types are the same  */
@@ -582,8 +582,8 @@ TYPEselect_inc_print_vars( const Type type, FILE * f, Linked_List dups ) {
          classnm [BUFSIZ],
          tdnm [BUFSIZ];
 
-    strncpy( classnm, SelectName( TYPEget_name( type ) ), BUFSIZ );
-    strncpy( tdnm, TYPEtd_name( type ), BUFSIZ );
+    strlcpy( classnm, SelectName( TYPEget_name( type ) ), BUFSIZ );
+    strlcpy( tdnm, TYPEtd_name( type ), BUFSIZ );
     size = strlen( classnm ) + 2; /* for formatting output */
 
     fprintf( f, "\n//////////  SELECT TYPE %s\n",
@@ -602,7 +602,7 @@ TYPEselect_inc_print_vars( const Type type, FILE * f, Linked_List dups ) {
     LISTod;
 
     LISTdo( data_members, t, Type )
-    strncpy( dmname, SEL_ITEMget_dmname( t ), BUFSIZ );
+    strlcpy( dmname, SEL_ITEMget_dmname( t ), BUFSIZ );
     fprintf( f, "\t   %s _%s;\n", TYPEget_utype( t ), dmname );
     LISTod;
 
@@ -681,8 +681,8 @@ TYPEselect_inc_print( const Type type, FILE * f ) {
     Linked_List attrs;
 
     dup_result = find_duplicate_list( type, &dups );
-    strncpy( n, SelectName( TYPEget_name( type ) ), BUFSIZ );
-    strncpy( tdnm, TYPEtd_name( type ), BUFSIZ );
+    strlcpy( n, SelectName( TYPEget_name( type ) ), BUFSIZ );
+    strlcpy( tdnm, TYPEtd_name( type ), BUFSIZ );
     TYPEselect_inc_print_vars( type, f, dups );
 
     fprintf( f, "\n\t//  part 2\n" );
@@ -807,8 +807,8 @@ TYPEselect_lib_print_part_one( const Type type, FILE * f, Schema schema,
          nm[BUFSIZ];
     int size = strlen( n ) * 2 + 4, j; /* size - for formatting output */
 
-    strncpy( tdnm, TYPEtd_name( type ), BUFSIZ );
-    strncpy( nm, SelectName( TYPEget_name( type ) ), BUFSIZ );
+    strlcpy( tdnm, TYPEtd_name( type ), BUFSIZ );
+    strlcpy( nm, SelectName( TYPEget_name( type ) ), BUFSIZ );
 
     /*  constructor(s)  */
     /*  null constructor  */
@@ -1039,11 +1039,11 @@ TYPEselect_lib_print_part_three( const Type type, FILE * f, Schema schema,
         generate_attribute_func_name( a, funcnm );
         generate_attribute_name( a, attrnm );
         /*
-            strncpy (funcnm, attrnm, BUFSIZ);
+            strlcpy (funcnm, attrnm, BUFSIZ);
             funcnm [0] = toupper (funcnm[0]);
         */
         /*  use the ctype since utype will be the same for all entities  */
-        strncpy( utype, TYPEget_ctype( VARget_type( a ) ), BUFSIZ );
+        strlcpy( utype, TYPEget_ctype( VARget_type( a ) ), BUFSIZ );
 
         /*   get method  */
         ATTRprint_access_methods_get_head( classnm, a, f );
@@ -1076,7 +1076,7 @@ TYPEselect_lib_print_part_three( const Type type, FILE * f, Schema schema,
                         the same as the current attribute.
                         */
 
-                    strncpy( uent, TYPEget_ctype( t ), BUFSIZ );
+                    strlcpy( uent, TYPEget_ctype( t ), BUFSIZ );
 
                     /*  if the underlying type is that item\'s type
                     call the underlying_item\'s member function  */
@@ -1184,7 +1184,7 @@ TYPEselect_lib_print_part_three( const Type type, FILE * f, Schema schema,
                         generate_attribute_func_name( a, funcnm );
                     }
 
-                    strncpy( uent, TYPEget_ctype( t ), BUFSIZ );
+                    strlcpy( uent, TYPEget_ctype( t ), BUFSIZ );
                     fprintf( f,
                              "  if( CurrentUnderlyingType () == %s ) \n\t//  %s\n",
                              TYPEtd_name( t ), StrToUpper( TYPEget_name( t ) ) );
@@ -1259,7 +1259,7 @@ TYPEselect_lib_print_part_four( const Type type, FILE * f, Schema schema,
     fprintf( f, "%s& %s::operator =( const %s_ptr& o )\n{\n", n, n, n );
 
     LISTdo( SEL_TYPEget_items( type ), t, Type )
-    strncpy( x, TYPEget_name( t ), BUFSIZ );
+    strlcpy( x, TYPEget_name( t ), BUFSIZ );
     if( firsttime ) {
         fprintf( f, "   " );
         firsttime = 0;
@@ -1300,7 +1300,7 @@ TYPEselect_lib_print_part_four( const Type type, FILE * f, Schema schema,
 
     firsttime = 1;
     LISTdo( SEL_TYPEget_items( type ), t, Type )
-    strncpy( x, TYPEget_name( t ), BUFSIZ );
+    strlcpy( x, TYPEget_name( t ), BUFSIZ );
     if( firsttime ) {
         fprintf( f, "   " );
         firsttime = 0;
@@ -1350,7 +1350,7 @@ TYPEselect_lib_print_part_four( const Type type, FILE * f, Schema schema,
     fprintf( f, "SDAI_Select& %s::ShallowCopy ( const SDAI_Select& o )\n{\n", n );
 
     LISTdo( SEL_TYPEget_items( type ), t, Type )
-    strncpy( x, TYPEget_name( t ), BUFSIZ );
+    strlcpy( x, TYPEget_name( t ), BUFSIZ );
     fprintf( f, "   if( o.CurrentUnderlyingType () == %s )\n",
              TYPEtd_name( t ) );
     if( utype_member( dups, t, 1 ) )
@@ -1392,7 +1392,7 @@ TYPEselect_lib_part21( const Type type, FILE * f, Schema schema ) {
     const char * dm;  /*  data member name */
     Linked_List data_members = SELgetnew_dmlist( type );
 
-    strncpy( n, SelectName( TYPEget_name( type ) ), BUFSIZ );
+    strlcpy( n, SelectName( TYPEget_name( type ) ), BUFSIZ );
 
     fprintf( f, "\n\n// STEP Part 21\n" );
     /*  write part 21   */
@@ -1666,7 +1666,7 @@ TYPEselect_lib_StrToVal( const Type type, FILE * f, Schema schema ) {
     Linked_List data_members = SELgetnew_dmlist( type );
     int enum_cnt = 0;
 
-    strncpy( n, SelectName( TYPEget_name( type ) ), BUFSIZ );
+    strlcpy( n, SelectName( TYPEget_name( type ) ), BUFSIZ );
 
     /*  read StrToVal_content   */
     fprintf( f, "\nSeverity\n%s::StrToVal_content "
@@ -1834,7 +1834,7 @@ TYPEselect_lib_print( const Type type, FILE * f, Schema schema ) {
     int dup_result;
 
     dup_result = find_duplicate_list( type, &dups );
-    strncpy( n, SelectName( TYPEget_name( type ) ), BUFSIZ );
+    strlcpy( n, SelectName( TYPEget_name( type ) ), BUFSIZ );
     fprintf( f, "\n//////////  SELECT TYPE %s\n", TYPEget_name( type ) );
 
     SELlib_print_protected( type,  f,  schema )  ;
@@ -1879,7 +1879,7 @@ TYPEselect_lib_print( const Type type, FILE * f, Schema schema ) {
         fprintf( f, "%s::operator %s()\n{\n", n,
                  ( TYPEis_aggregate( t ) || TYPEis_select( t ) ) ?
                  AccessType( t ) : TYPEget_utype( t ) );
-        strncpy( m, TYPEget_utype( t ), BUFSIZ );
+        strlcpy( m, TYPEget_utype( t ), BUFSIZ );
 
         /**** MUST CHANGE FOR multiple big types ****/
         LISTdo( SEL_TYPEget_items( type ), x, Type )
@@ -2001,8 +2001,8 @@ TYPEselect_print( Type t, FILES * files, Schema schema ) {
         if( !TYPEget_clientData( i ) ) {
             TYPEselect_print( i, files, schema );
         }
-        strncpy( nm, SelectName( TYPEget_name( t ) ), BUFSIZ );
-        strncpy( tdnm, TYPEtd_name( t ), BUFSIZ );
+        strlcpy( nm, SelectName( TYPEget_name( t ) ), BUFSIZ );
+        strlcpy( tdnm, TYPEtd_name( t ), BUFSIZ );
         fprintf( inc, "typedef %s *    \t%sH;\n", nm, nm );
         fprintf( inc, "typedef %s_ptr *\t%s_var;\n", nm, nm );
         /* Below are specialized create functions for the renamed sel type (both


### PR DESCRIPTION
strlcpy is known to provide a safer implementation than strncpy (cppcheck reports many `(error) Dangerous usage of '*' (strncpy doesn't always 0-terminate it)`).
