### PR TITLE
fix bug with binary values not being saved to disk

### DIFF
--- a/src/clstepcore/STEPattribute.cc
+++ b/src/clstepcore/STEPattribute.cc
@@ -790,7 +790,6 @@ int STEPattribute::is_null()  const {
             return ( *( ptr.S ) == S_STRING_NULL );
 
         case BINARY_TYPE:
-            ptr.b->clear();
             return ptr.b->empty();
 
         case AGGREGATE_TYPE:


### PR DESCRIPTION
For SDAI_Binary, `STEPattribute::is_null()` cleared the value instead of
merely reporting whether it was null, like it does with other types.
