### PR TITLE
Fixes to get fedex_plus working in release build on MSVC2010.

### DIFF
--- a/src/exppp/CMakeLists.txt
+++ b/src/exppp/CMakeLists.txt
@@ -14,7 +14,7 @@ include_directories(
 )
 
 
-if(BORLAND)
+if( MSVC OR BORLAND)
     add_definitions( -D__STDC__ )
 endif()
 

--- a/src/express/CMakeLists.txt
+++ b/src/express/CMakeLists.txt
@@ -78,7 +78,7 @@ if(MSVC OR BORLAND)
 add_definitions( -DYY_NO_UNISTD_H )
 endif()
 
-if(BORLAND)
+if(MSVC OR BORLAND)
     add_definitions( -D__STDC__ )
 endif()
 

--- a/src/fedex_plus/classes.c
+++ b/src/fedex_plus/classes.c
@@ -1918,6 +1918,7 @@ bool TYPEis_builtin( const Type t ) {
  */
 void AGGRprint_init( FILES* files, const Type t, const char* var_name, const char* aggr_name ) {
     if( !TYPEget_head( t ) ) {
+        #ifdef YYDEBUG
         if( yydebug ) {
             if ( !t->superscope->symbol.resolved ) {
                 printf("%s:%d: unresolved type %s at %d\n",__FILE__,__LINE__, t->superscope->symbol.name, t->superscope->symbol.line);
@@ -1934,6 +1935,7 @@ void AGGRprint_init( FILES* files, const Type t, const char* var_name, const cha
                 }
             }
         }
+        #endif
         //the code for lower and upper is almost identical
         if( TYPEget_body( t )->lower ) {
             if (TYPEget_body( t )->lower->symbol.resolved ) {


### PR DESCRIPTION
- Added **STDC** define for MSVC builds, seems otherwise an access violation occurs on release builds.
- Added #ifdef YYDEBUG to fix build issue in fedex_plus release build.
