### PR TITLE
Add AP214/AP242 merged schema

### DIFF
--- a/data/STEPTools_merged_schema/modified_step_merged_cad_schema.exp
+++ b/data/STEPTools_merged_schema/modified_step_merged_cad_schema.exp
@@ -1,5 +1,14 @@
 SCHEMA step_merged_cad_schema;
 
+(* this is a MODIFIED version of the merged schema
+ * original is at http://www.steptools.com/support/stdev_docs/stpcad/step_merged_cad_schema.exp
+ *
+ * modified to eliminate fedex_plus errors. To view changes, use one of
+ * - `git log -p data/STEPTools_merged_schema/step_merged_cad_schema.exp`
+ * - http://github.com/stepcode/stepcode/commits/master/data/STEPTools_merged_schema
+ *)
+
+
 (* Constructed by merging:
  *  - AP242 (wg12n8324_ap242dis.exp)
  *  - AP214 (wg3n2628_ap214e3.exp)


### PR DESCRIPTION
This schema was created by STEPTools. According to the comment, it was

```
(* Constructed by merging:
 *  - AP242 (wg12n8324_ap242dis.exp)
 *  - AP214 (wg3n2628_ap214e3.exp)
 *  - AP203e2 (wg3n2635_ap203e2.exp)
 *  - Deprecated AP203e1 (ap203e1_types.exp)
 *  - AP242 DIS Fixes (ap242_fixes.exp)
 *)
```

I made some more modifications to eliminate errors reported by fedex_plus. This was done by **commenting out(!)** a where rule and parts of several functions, and adding an additional supertype to one entity. I added a comment to the file noting these changes.

@starseeker here's your schema :)
