### PR TITLE
trivial fix for #241, exppp segfault

### DIFF
--- a/src/exppp/exppp.c
+++ b/src/exppp/exppp.c
@@ -321,7 +321,9 @@ SCHEMAout( Schema s ) {
                 described = true;
             }
         }
-        fclose( f );
+        if( f ) {
+            fclose( f );
+        }
     }
     error_sym.filename = filename;
 


### PR DESCRIPTION
[test results](https://travis-ci.org/stepcode/stepcode/builds/9161359) are unaffected, since the exppp executable is not used in any tests.
