### PR TITLE
Use basic_string::clear() instead of basic_string::assign(0, 0).

### DIFF
--- a/src/cllazyfile/sectionReader.cc
+++ b/src/cllazyfile/sectionReader.cc
@@ -83,7 +83,7 @@ std::streampos sectionReader::findNormalString( const std::string & str, bool se
 const char * sectionReader::getDelimitedKeyword( const char * delimiters ) {
     static std::string str;
     char c;
-    str.assign( 0, 0 ); //clear() frees the memory
+    str.clear();
     str.reserve( 100 );
     skipWS();
     while( c = _file.get(), _file.good() ) {


### PR DESCRIPTION
The latter is an ambiguous call and makes the build fail with libc++:

 /s/stepcode/src/cllazyfile/sectionReader.cc:86:9: error: call to member
   function 'assign' is ambiguous
     str.assign( 0, 0 ); //clear() frees the memory
     ~~~~^~~~~~
 /usr/include/c++/v1/string:1354:19: note: candidate function
     basic_string& assign(const value_type\* __s, size_type __n);
                   ^
 /usr/include/c++/v1/string:1356:19: note: candidate function
     basic_string& assign(size_type __n, value_type __c);
                   ^
 /usr/include/c++/v1/string:1360:14: note: candidate template ignored:
   disabled by 'enable_if' [with _InputIterator = int]
              __is_input_iterator  <_InputIterator>::value &&
              ^
 /usr/include/c++/v1/string:1368:13: note: candidate template ignored:
   disabled by 'enable_if' [with _ForwardIterator = int]
             __is_forward_iterator<_ForwardIterator>::value,
             ^
 /usr/include/c++/v1/string:1347:19: note: candidate function not viable:
   requires single argument '__str', but 2 arguments were provided
     basic_string& assign(const basic_string& __str);
                   ^
 /usr/include/c++/v1/string:1353:19: note: candidate function not viable:
   requires 3 arguments, but 2 were provided
     basic_string& assign(const basic_string& __str, size_type __pos,
   size_type __n);
                   ^
 /usr/include/c++/v1/string:1355:19: note: candidate function not viable:
   requires single argument '__s', but 2 arguments were provided
     basic_string& assign(const value_type\* __s);
                   ^

Instead, just call clear(), which should do the same thing and, contrary to 
what the comment stated, does not clear the allocated memory.
