### PR TITLE
Fix MSVC warnings in dictSchema.cc and dirobj.cc

### DIFF
--- a/src/clstepcore/dictSchema.cc
+++ b/src/clstepcore/dictSchema.cc
@@ -69,7 +69,8 @@ void Schema::GenerateExpress( ostream & out ) const {
     out << endl << "(* ////////////// ENTITY Definitions *)" << endl;
     GenerateEntitiesExpress( out );
 
-    int count, i;
+    size_t count;
+    int i;
     if( _global_rules != 0 ) {
         out << endl << "(* *************RULES************* *)" << endl;
         count = _global_rules->Count();

--- a/src/clutils/dirobj.cc
+++ b/src/clutils/dirobj.cc
@@ -260,7 +260,7 @@ const char * DirObj::ValidDirectories( const char * path ) {
     static char buf[MAXPATHLEN + 1];
 #endif
     strcpy( buf, path );
-    int i = strlen( path );
+    size_t i = strlen( path );
 
     while( !IsADirectory( RealPath( buf ) ) && i >= 0 ) {
         for( --i; buf[i] != '/' && i >= 0; --i ) {


### PR DESCRIPTION
Use size_t instead of int to fix two instances of "warning C4267: '=' : conversion from 'size_t' to 'int', possible loss of data". #317