### PR TITLE
fix header installation - remove sc_stdbool.h from src/base/CMakeLists.t...

### DIFF
--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -12,7 +12,6 @@ set(SC_BASE_HDRS
   sc_memmgr.h
   sc_getopt.h
   sc_trace_fprintf.h
-  sc_stdbool.h
   sc_mkdir.h
  )
 


### PR DESCRIPTION
...xt, is already in include/CMakeLists.txt

This fixes a make install failure for me, I'm guessing sc_stdbool.h was moved and CMakeLists.txt was not updated in the old directory... just a guess though!  Seems to work.