### PR TITLE
Exp2python remove exppp dependency

### DIFF
--- a/src/exp2python/CMakeLists.txt
+++ b/src/exp2python/CMakeLists.txt
@@ -2,7 +2,6 @@ if(SC_PYTHON_GENERATOR)
 
   include_directories(
     ${SC_SOURCE_DIR}/include
-    ${SC_SOURCE_DIR}/include/exppp
     ${SC_SOURCE_DIR}/include/express
     ${SC_SOURCE_DIR}/src/base
    )
@@ -30,7 +29,7 @@ if(SC_PYTHON_GENERATOR)
     ../exp2cxx/write.cc
     ../exp2cxx/print.cc
    )
-  SC_ADDEXEC(exp2python "${exp2python_SOURCES}" "libexppp;express;base")
+  SC_ADDEXEC(exp2python "${exp2python_SOURCES}" "express;base")
 
   add_dependencies(exp2python version_string)
 endif(SC_PYTHON_GENERATOR)

--- a/src/exp2python/src/classes.h
+++ b/src/exp2python/src/classes.h
@@ -23,7 +23,6 @@ N350 ( August 31, 1993 ) of ISO 10303 TC184/SC4/WG7.
 
 
 #include "express.h"
-#include "exppp.h"
 #include "dict.h"
 
 #define MAX_LEN              240

--- a/src/exp2python/src/classes_misc_python.c
+++ b/src/exp2python/src/classes_misc_python.c
@@ -605,7 +605,7 @@ VARis_type_shifter( Variable a ) {
         return 0;
     }
 
-    temp = EXPRto_string( VARget_name( a ) );
+    temp = strdup( VARget_name( a ) );
     if( ! strncmp( StrToLower( temp ), "self\\", 5 ) ) {
         /*    a is a type shifter */
         free( temp );

--- a/src/exp2python/src/classes_python.c
+++ b/src/exp2python/src/classes_python.c
@@ -102,6 +102,8 @@ void CASEout( struct Case_Statement_ *c, int level, FILE * file );
 void LOOPpyout( struct Loop_ *loop, int level, FILE * file );
 void WHEREPrint( Linked_List wheres, int level , FILE * file );
 
+void Type_Description( const Type, char * );
+
 char * EXPRto_python( Expression e );
 
 /*
@@ -1980,29 +1982,6 @@ TYPEenum_lib_print( const Type type, FILE * f ) {
         }
     }
     fprintf( f, "')\n" );
-}
-
-
-
-void Type_Description( const Type, char * );
-
-/* return printable version of entire type definition */
-/* return it in static buffer */
-char *
-TypeDescription( const Type t ) {
-    static char buf[4000];
-
-    buf[0] = '\0';
-
-    if( TYPEget_head( t ) ) {
-        Type_Description( TYPEget_head( t ), buf );
-    } else {
-        TypeBody_Description( TYPEget_body( t ), buf );
-    }
-
-    /* should also print out where clause here */
-
-    return buf + 1;
 }
 
 void strcat_expr( Expression e, char * buf ) {


### PR DESCRIPTION
It's never made much sense to me to use the EXPRESS output pretty printer for writing Python code - so I've removed that dependency.

Also - this commit now produces valid module Python code for AP242 (manual tweaking is still required to fix an indentation error and function definition position in the output).  I haven't done anything other than import the code.

Next step further work on the integration of the Part21 plan!

There's a workaround for enumeration subexpressions (top of ATTRIBUTE_INITIALIZERop__out function) - I tend to think that these should be absorded into a single expression during the EXPRESS parsing stage, but haven't had the opportunity to investigate that.