### PR TITLE
exppp - supertype parens

### DIFF
--- a/src/exppp/pretty_expr.c
+++ b/src/exppp/pretty_expr.c
@@ -140,7 +140,7 @@ void EXPR__out( Expression e, int paren, unsigned int previous_op ) {
             if( i != 1 ) {
                 raw( ", " );
             }
-            EXPR_out( arg, 0 );
+            EXPR_out( arg, 1 );
             LISTod
 
             if( exppp_linelength == indent2 ) {

--- a/src/exppp/test/CMakeLists.txt
+++ b/src/exppp/test/CMakeLists.txt
@@ -58,7 +58,14 @@ add_test(NAME test_exppp_div_slash
   -P ${CMAKE_CURRENT_SOURCE_DIR}/exppp_div_slash.cmake
   )
 
-set_tests_properties(test_exppp_unique_qualifiers test_exppp_inverse_qualifiers test_exppp_lost_var test_exppp_div_slash PROPERTIES DEPENDS build_exppp)
+add_test(NAME test_exppp_supertype_andor
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  COMMAND ${CMAKE_COMMAND} -DEXPPP=$<TARGET_FILE:exppp>
+  -DINFILE=${CMAKE_CURRENT_SOURCE_DIR}/exppp_supertype_andor.exp
+  -P ${CMAKE_CURRENT_SOURCE_DIR}/exppp_supertype_andor.cmake
+  )
+
+  set_tests_properties(test_exppp_unique_qualifiers test_exppp_inverse_qualifiers test_exppp_lost_var test_exppp_div_slash test_exppp_supertype_andor PROPERTIES DEPENDS build_exppp)
 
 # Local Variables:
 # tab-width: 8

--- a/src/exppp/test/exppp_supertype_andor.cmake
+++ b/src/exppp/test/exppp_supertype_andor.cmake
@@ -1,0 +1,28 @@
+ 
+cmake_minimum_required( VERSION 2.8 )
+
+# executable is ${EXPPP}, input file is ${INFILE}
+
+set( ofile "exppp_supertype_andor_out.exp" )
+execute_process( COMMAND ${EXPPP} -o ${ofile} ${INFILE}
+  RESULT_VARIABLE CMD_RESULT )
+if( NOT ${CMD_RESULT} EQUAL 0 )
+  message(FATAL_ERROR "Error running ${EXPPP} on ${INFILE}")
+endif( NOT ${CMD_RESULT} EQUAL 0 )
+
+# file( READ ${INFILE} pretty_in LIMIT 1024 )
+file( READ ${ofile} pretty_out LIMIT 1024 )
+
+# need to be 3 parens after path
+string(FIND "${pretty_out}" "path ) ) )" match_result )
+if( match_result LESS 1 )
+  message( FATAL_ERROR "Pretty printer output does not match input." )
+endif( match_result LESS 1 )
+
+# Local Variables:
+# tab-width: 8
+# mode: cmake
+# indent-tabs-mode: t
+# End:
+# ex: shiftwidth=2 tabstop=8
+

--- a/src/exppp/test/exppp_supertype_andor.exp
+++ b/src/exppp/test/exppp_supertype_andor.exp
@@ -1,0 +1,38 @@
+(* reported as issue #318
+ENTITY Detailed_topological_model_element
+   ABSTRACT SUPERTYPE OF (ONEOF (
+                        CONNECTED_EDGE_SET,
+                        CONNECTED_FACE_SET,
+                        EDGE,
+                        FACE,
+                        FACE_BOUND,
+                        VERTEX,(           --paren missing in output
+                        LOOP
+                        ANDOR
+                        PATH)))            --paren missing in output
+  SUBTYPE OF (Representation_item);
+END_ENTITY;
+*)
+
+SCHEMA supertype_andor;
+
+ENTITY DTME
+  ABSTRACT SUPERTYPE OF (ONEOF (
+    VERTEX,
+    (LOOP
+     ANDOR
+     PATH)
+  ));
+END_ENTITY;
+
+ENTITY VERTEX
+  SUBTYPE OF (DTME);
+END_ENTITY;
+ENTITY LOOP
+  SUBTYPE OF (DTME);
+END_ENTITY;
+ENTITY PATH
+  SUBTYPE OF (DTME);
+END_ENTITY;
+
+END_SCHEMA;


### PR DESCRIPTION
ANDOR statement was missing parenthesis in pretty printed output.

Closes #318 