### PR TITLE
make Python Part21 lexer more extensible for writing custom parser rules

### DIFF
--- a/src/exp2python/python/SCL/Part21.py
+++ b/src/exp2python/python/SCL/Part21.py
@@ -203,6 +203,8 @@ class TypedParameter:
 # Parser
 ####################################################################################################
 class Parser(Base):
+    start = 'exchange_file'
+
     def __init__(self, lexer=None, debug=0):
         self.parser = yacc.yacc(module=self, debug=debug, debuglog=logger, errorlog=logger)
 

--- a/src/exp2python/python/SCL/Part21.py
+++ b/src/exp2python/python/SCL/Part21.py
@@ -225,7 +225,7 @@ class Parser(Base):
         return result
 
     def p_exchange_file(self, p):
-        """exchange_file : p21_start header_section data_section_list part21_end"""
+        """exchange_file : p21_start header_section data_section_list p21_end"""
         p[0] = P21File(p[2], p[3])
 
     def p_p21_start(self, p):

--- a/src/exp2python/python/SCL/Part21.py
+++ b/src/exp2python/python/SCL/Part21.py
@@ -34,7 +34,6 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 # THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import sys
 import logging
 import ply.lex as lex
 import ply.yacc as yacc
@@ -74,10 +73,8 @@ class Lexer(Base):
 
     def input(self, s):
         startidx = s.find('ISO-10303-21;', 0, self.header_limit)
-        # TODO: It would be better to raise a suitable exception and
-        #       let the application decide how to handle it.
         if startidx == -1:
-            sys.exit('Aborting... ISO-10303-21; header not found')
+            raise ValueError('ISO-10303-21 header not found')
         self.lexer.input(s[startidx:])
         self.lexer.lineno += s[0:startidx].count('\n')
 
@@ -260,7 +257,7 @@ class Parser(Base):
         """check_entity_instance_name : ENTITY_INSTANCE_NAME"""
         if p[1] in self.refs:
             logger.error('Line %i, duplicate entity instance name: %s', p.lineno(1), p[1])
-            sys.exit('Aborting...')
+            raise ValueError('Duplicate entity instance name')
         else:
             self.refs[p[1]] = None
             p[0] = p[1]


### PR DESCRIPTION
This makes it easier to implement a parser by subclassing SCL.Part21.Lexer, adding additional entities (or entity->type mappings if you need more flexible control for implementing a subclass of SCL.Part21.Parser)
