### PR TITLE
Fixed typos showing up as ascii chars

### DIFF
--- a/src/exp2python/python/SCL/AggregationDataTypes.py
+++ b/src/exp2python/python/SCL/AggregationDataTypes.py
@@ -69,7 +69,7 @@ class ARRAY(BaseType.Type, BaseType.Aggregate):
     """
     EXPRESS definition:
     ==================
-    An array data type has as its domain indexed, fixed-size collections of like elements. The lower
+    An array data type has as its domain indexed, fixed-size collections of like elements. The lower
     and upper bounds, which are integer-valued expressions, define the range of index values, and
     thus the size of each array collection.
     An array data type definition may optionally specify
@@ -93,21 +93,21 @@ class ARRAY(BaseType.Type, BaseType.Aggregate):
     NOTE 1 { The bounds may be positive, negative or zero, but may not be indeterminate (?) (see
     14.2).
     Rules and restrictions:
-    a) Both expressions in the bound specication, bound_1 and bound_2, shall evaluate to
+    a) Both expressions in the bound specification, bound_1 and bound_2, shall evaluate to
     integer values. Neither shall evaluate to the indeterminate (?) value.
     b) bound_1 gives the lower bound of the array. This shall be the lowest index which is
     valid for an array value of this data type.
     c) bound_2 gives the upper bound of the array. This shall be the highest index which is
     valid for an array value of this data type.
     d) bound_1 shall be less than or equal to bound_2.
-    e) If the optional keyword is specied, an array value of this data type may have the
+    e) If the optional keyword is specified, an array value of this data type may have the
     indeterminate (?) value at one or more index positions.
-    f) If the optional keyword is not specied, an array value of this data type shall not
+    f) If the optional keyword is not specified, an array value of this data type shall not
     contain an indeterminate (?) value at any index position.
-    g) If the unique keyword is specied, each element in an array value of this data type
-    shall be dierent from (i.e., not instance equal to) every other element in the same array
+    g) If the unique keyword is specified, each element in an array value of this data type
+    shall be different from (i.e., not instance equal to) every other element in the same array
     value.
-    NOTE 2 : Both optional and unique may be specied in the same array data type definition.
+    NOTE 2 : Both optional and unique may be specified in the same array data type definition.
     This does not preclude multiple indeterminate (?) values from occurring in a single array value.
     This is because comparisons between indeterminate (?) values result in unknown so the uniqueness
     constraint is not violated.
@@ -115,7 +115,7 @@ class ARRAY(BaseType.Type, BaseType.Aggregate):
     sectors : ARRAY [ 1 : 10 ] OF -- first dimension
     ARRAY [ 11 : 14 ] OF -- second dimension
     UNIQUE something;
-    The first array has 10 elements of data type ARRAY[11:14] OF UNIQUE something. There is
+    The first array has 10 elements of data type ARRAY[11:14] OF UNIQUE something. There is
     a total of 40 elements of data type something in the attribute named sectors. Within each
     ARRAY[11:14], no duplicates may occur; however, the same something instance may occur in two
     different ARRAY[11:14] values within a single value for the attribute named sectors.
@@ -223,10 +223,10 @@ class LIST(BaseType.Type, BaseType.Aggregate):
     If this value is indeterminate (?) the number of elements in a list value of this data type is
     not bounded from above.
     c) If the bound_spec is omitted, the limits are [0:?].
-    d) If the unique keyword is specied, each element in a list value of this data type shall
-    be dierent from (i.e., not instance equal to) every other element in the same list value.
-    EXAMPLE 28 { This example denes a list of arrays. The list can contain zero to ten arrays. Each
-    array of ten integers shall be dierent from all other arrays in a particular list.
+    d) If the unique keyword is specified, each element in a list value of this data type shall
+    be different from (i.e., not instance equal to) every other element in the same list value.
+    EXAMPLE 28 { This example defines a list of arrays. The list can contain zero to ten arrays. Each
+    array of ten integers shall be different from all other arrays in a particular list.
     complex_list : LIST[0:10] OF UNIQUE ARRAY[1:10] OF INTEGER;
     
     Python definition:
@@ -374,7 +374,7 @@ class BAG(BaseType.Type, BaseType.Aggregate):
     ==================
     A bag data type has as its domain unordered collections of like elements. The optional lower
     and upper bounds, which are integer-valued expressions, define the minimum and maximum
-    number of elements that can be held in the collection dened by a bag data type.
+    number of elements that can be held in the collection defined by a bag data type.
     
     Syntax:
     170 bag_type = BAG [ bound_spec ] OF base_type .
@@ -490,8 +490,8 @@ class SET(BaseType.Type, BaseType.Aggregate):
     ==================
     A set data type has as its domain unordered collections of like elements. The set data type is
     a specialization of the bag data type. The optional lower and upper bounds, which are integer-
-    valued expressions, dene the minimum and maximum number of elements that can be held in
-    the collection dened by a set data type. The collection dened by set data type shall not
+    valued expressions, define the minimum and maximum number of elements that can be held in
+    the collection defined by a set data type. The collection defined by set data type shall not
     contain two or more elements which are instance equal.
     Syntax:
     285 set_type = SET [ bound_spec ] OF base_type .
@@ -509,14 +509,14 @@ class SET(BaseType.Type, BaseType.Aggregate):
     If this value is indeterminate (?) the number of elements in a set value of this data type is
     not be bounded from above.
     c) If the bound_spec is omitted, the limits are [0:?].
-    d) Each element in an occurrence of a set data type shall be dierent from (i.e., not
+    d) Each element in an occurrence of a set data type shall be different from (i.e., not
     instance equal to) every other element in the same set value.
-    EXAMPLE 30 { This example denes an attribute as a set of points (a named data type assumed
+    EXAMPLE 30 { This example defines an attribute as a set of points (a named data type assumed
     to have been declared elsewhere).
     a_set_of_points : SET OF point;
     The attribute named a_set_of_points can contain zero or more points. Each point instance (in
-    the set value) is required to be dierent from every other point in the set.
-    If the value is required to have no more than 15 points, the specication can provide an upper bound,
+    the set value) is required to be different from every other point in the set.
+    If the value is required to have no more than 15 points, the specification can provide an upper bound,
     as in:
     a_set_of_points : SET [0:15] OF point;
     The value of the attribute named a_set_of_points now may contain no more than 15 points.

--- a/src/exp2python/python/SCL/Builtin.py
+++ b/src/exp2python/python/SCL/Builtin.py
@@ -50,8 +50,8 @@ CONST_E = REAL(math.pi)
 #14.2 Indeterminate
 #The indeterminate symbol (?) stands for an ambiguous value. It is compatible with all data
 #types.
-#NOTE - The most common use of indeterminate (?) is as the upper bound specication of a bag,
-#list or set. This usage represents the notion that the size of the aggregate value dened by the
+#NOTE - The most common use of indeterminate (?) is as the upper bound specification of a bag,
+#list or set. This usage represents the notion that the size of the aggregate value defined by the
 #aggregation data type is unbounded.
 # python note: indeterminate value is mapped to None in aggregate bounds
 
@@ -65,7 +65,7 @@ FALSE = False
 # EXPRESS definition:
 # ===================
 #14.4 Pi
-#PI is a REAL constant representing the mathematical value , the ratio of a circle's circumference
+#PI is a REAL constant representing the mathematical value π, the ratio of a circle's circumference
 #to its diameter.
 PI = REAL(math.pi)
 
@@ -74,7 +74,7 @@ PI = REAL(math.pi)
 #14.5 Self
 #SELF refers to the current entity instance or type value. self may appear within an entity
 #declaration, a type declaration or an entity constructor.
-#NOTE - sSELF is not a constant, but behaves as one in every context in which it can appear.
+#NOTE - SELF is not a constant, but behaves as one in every context in which it can appear.
 # python note: SELF is not mapped to any constant, but is mapper to self
 
 # EXPRESS definition:
@@ -87,7 +87,7 @@ TRUE = True
 # EXPRESS definition:
 # ===================
 #14.7 Unknown
-#unknown is a logical constant representing that there is insucient information available to
+#unknown is a logical constant representing that there is insufficient information available to
 #be able to evaluate a logical condition. It is compatible with the logical data type, but not
 #with the boolean data type.
 # @TODO: define UNKNOWN in python
@@ -122,7 +122,7 @@ def ABS(V):
 #FUNCTION ACOS ( V:NUMBER ) : REAL;
 #The acos function returns the angle given a cosine value.
 #Parameters : V is a number which is the cosine of an angle.
-#Result : The angle in radians (0  result  ) whose cosine is V.
+#Result : The angle in radians (0 <= result <= pi) whose cosine is V.
 #Conditions : -1.0=<V<=1.0
 #EXAMPLE 126 { ACOS ( 0.3 ) --> 1.266103...
 # Python definition:
@@ -149,7 +149,7 @@ def ASIN(V):
 #a) V1 is a number.
 #b) V2 is a number.
 #Result : The angle in radians (-pi/2<=result<=pi/2) whose tangent is V. If V2 is zero, the result
-#is pi/2 or -pi/2 depending on the sign of V1.
+#is pi/2 or -pi/2 depending on the sign of V1.
 #Conditions : Both V1 and V2 shall not be zero.
 #EXAMPLE 128 { ATAN ( -5.5, 3.0 ) --> -1.071449...
 def ATAN(V1,V2):
@@ -197,7 +197,7 @@ def BLENGTH(V):
 #FUNCTION SIN ( V:NUMBER ) : REAL;
 #The sin function returns the sine of an angle.
 #Parameters : V is a number representing an angle expressed in radians.
-#Result : The sine of V (-1.0  result  1.0).
+#Result : The sine of V (-1.0 <= result <= 1.0).
 #EXAMPLE 144 { SIN ( PI ) --> 0.0
 #
 def COS(V):
@@ -487,14 +487,14 @@ def ODD(V):
 # ===================  
 #15.20 RolesOf - general function
 #FUNCTION ROLESOF ( V:GENERIC ) : SET OF STRING;
-#The rolesof function returns a set of strings containing the fully qualied names of the roles
-#played by the specied entity instance. A fully qualied name is dened to be the name of the
-#attribute qualied by the name of the schema and entity in which this attribute is declared (i.e.
+#The rolesof function returns a set of strings containing the fully qualified names of the roles
+#played by the specified entity instance. A fully qualified name is defined to be the name of the
+#attribute qualified by the name of the schema and entity in which this attribute is declared (i.e.
 #'SCHEMA.ENTITY.ATTRIBUTE').
 #Parameters : V is any instance of an entity data type.
-#Result : A set of string values (in upper case) containing the fully qualied names of the
+#Result : A set of string values (in upper case) containing the fully qualified names of the
 #attributes of the entity instances which use the instance V.
-#When a named data type is use'd or reference'd, the schema and the name in that schema,
+#When a named data type is used or referenced, the schema and the name in that schema,
 #if renamed, are also returned. Since use statements may be chained, all the chained schema
 #names and the name in each schema are returned.
 #EXAMPLE 143 { This example shows that a point might be used as the centre of a circle. The
@@ -567,7 +567,7 @@ def SIZEOF(V):
 #The sqrt function returns the non-negative square root of a number.
 #Parameters : V is any non-negative number.
 #Result : The non-negative square root of V.
-#Conditions : V  0:0
+#Conditions : V >= 0:0
 #EXAMPLE 146 - SQRT ( 121 ) --> 11.0
 def SQRT(V):
     if not isinstance(V,NUMBER):
@@ -602,16 +602,16 @@ def TAN(V):
 #The typeof function returns a set of strings that contains the names of all the data types
 #of which the parameter is a member. Except for the simple data types (binary, boolean,
 #integer, logical, number, real, and string) and the aggregation data types (array, bag,
-#list, set) these names are qualied by the name of the schema which contains the denition of
+#list, set) these names are qualified by the name of the schema which contains the definition of
 #the type.
 #NOTE 1 { The primary purpose of this function is to check whether a given value (variable, at-
 #tribute value) can be used for a certain purpose, e.g. to ensure assignment compatibility between
-#two values. It may also be used if dierent subtypes or specializations of a given type have to be
-#treated dierently in some context.
+#two values. It may also be used if different subtypes or specializations of a given type have to be
+#treated differently in some context.
 #Parameters : V is a value of any type.
 #Result : The contents of the returned set of string values are the names (in upper case) of all
-#types the value V is a member of. Such names are qualied by the name of the schema which
-#contains the denition of the type ('SCHEMA.TYPE') if it is neither a simple data type nor an
+#types the value V is a member of. Such names are qualified by the name of the schema which
+#contains the definition of the type ('SCHEMA.TYPE') if it is neither a simple data type nor an
 #aggregation data type. It may be derived by the following algorithm (which is given here for
 #specification purposes rather than to prescribe any particular type of implementation)
 def TYPEOF(V):
@@ -636,8 +636,8 @@ def TYPEOF(V):
 # ===================  
 #15.26 UsedIn - general function
 #FUNCTION USEDIN ( T:GENERIC; R:STRING) : BAG OF GENERIC;
-#The usedin function returns each entity instance that uses a specied entity instance in a
-#specied role.
+#The usedin function returns each entity instance that uses a specified entity instance in a
+#specified role.
 def USEDIN(T,R):
     raise NotImplemented("USEDIN function not yet implemented.")
 
@@ -654,8 +654,8 @@ def USEDIN(T,R):
 #VALUE ( 'abc' ) --> ? null
 def VALUE(V):
     if not isinstance(V,STRING):
-        raise TypeError("VALULE function takes a NUMBER parameter")
-    # first try to instanciate an INTEGER from the string:
+        raise TypeError("VALUE function takes a NUMBER parameter")
+    # first try to instantiate an INTEGER from the string:
     try:
         return INTEGER(V)
     except:
@@ -691,7 +691,7 @@ def VALUE(V):
 def VALUE_IN(C,V):
     if not isinstance(C,Aggregate):
         raise TypeError("VALUE_IN method takes an aggregate as first parameter")
-    raise NotImplemented("VALUE_IN function not et implemented")
+    raise NotImplemented("VALUE_IN function not yet implemented")
 
 # EXPRESS definition:
 # ===================  
@@ -705,8 +705,8 @@ def VALUE_IN(C,V):
 #b) If any any two elements of V are value equal, false is returned.
 #c) If any element of V is indeterminate (?), unknown is returned.
 #d) Otherwise true is returned.
-#EXAMPLE 153 { The following test ensures tht each point is a set is at a dierent position, (by
-#denition they are distinct, i.e., instance unique).
+#EXAMPLE 153 { The following test ensures that each point is placed at a different position, (by
+#definition they are distinct, i.e., instance unique).
 #IF VALUE_UNIQUE(points) THEN ...
 def VALUE_UNIQUE(V):
     if not isinstance(V,Aggregate):

--- a/src/exp2python/python/SCL/SimpleDataTypes.py
+++ b/src/exp2python/python/SCL/SimpleDataTypes.py
@@ -38,7 +38,7 @@ class NUMBER:
     EXPRESS definition:
     ===================
     The number data type has as its domain all numeric values in the language. The number data
-    type shall be used when a more specic numeric representation is not important.
+    type shall be used when a more specific numeric representation is not important.
     Syntax:
     248 number_type = NUMBER .
     EXAMPLE 15 - Since we may not know the context of size we do not know how to correctly
@@ -56,7 +56,7 @@ class REAL(float,NUMBER):
     """
     EXPRESS definition:
     ===================
-    The real data type has as its domain all rational, irrational and scientfic real numbers. It is
+    The real data type has as its domain all rational, irrational and scientific real numbers. It is
     a specialization of the number data type.
     Syntax:
     265 real_type = REAL [ '(' precision_spec ')' ] .
@@ -110,23 +110,23 @@ class INTEGER(int,NUMBER):
 class STRING(str):
     """
     The string data type has as its domain sequences of characters. The characters which are
-    permitted to form part of a string value are dened in ISO 10646.
+    permitted to form part of a string value are defined in ISO 10646.
     Syntax:
     293 string_type = STRING [ width_spec ] .
     318 width_spec = '(' width ')' [ FIXED ] .
     317 width = numeric_expression .
-    A string data type may be dened as either xed or varying width (number of characters). If
+    A string data type may be defined as either fixed or varying width (number of characters). If
     it is not specfically defined as fixed width (by using the fixed reserved word in the dfinition)
     the string has varying width.
     
-    The domain of a xed width string data type is the set of all character sequences of exactly
-    the width specied in the type denition.
+    The domain of a fixed width string data type is the set of all character sequences of exactly
+    the width specified in the type definition.
     The domain of a varying width string data type is the set of all character sequences of width
-    less than or equal to the maximum width specied in the type denition.
-    If no width is specied, the domain is the set of all character sequences, with no constraint on
+    less than or equal to the maximum width specified in the type definition.
+    If no width is specified, the domain is the set of all character sequences, with no constraint on
     the width of these sequences.
     Substrings and individual characters may be addressed using subscripts as described in 12.5.
-    The case (upper or lower) of letters within a string is signicant.
+    The case (upper or lower) of letters within a string is significant.
     
     Python mapping: INTEGER is mapped the 'str' type. An additional width_spec parameter can be passed
     to handle the FIXED length constraint
@@ -166,10 +166,10 @@ class BINARY(str):
     A binary data type may be defined as either fixed or varying width (number of bits). If it is
     not specifically defined as fixed width (by using the fixed reserved word in the definition) the
     binary data type has varying width.
-    The domain of a fixed width binary data type is the set of all bit sequences of exactly the width
-    specied in the type definition.
+    The domain of a fixed width binary data type is the set of all bit sequences of exactly the width
+    specified in the type definition.
     The domain of a varying width binary data type is the set of all bit sequences of width less
-    than or equal to the maximum width specied in the type denition. If no width is specified,
+    than or equal to the maximum width specified in the type definition. If no width is specified,
     the domain is the set of all bit sequences, with no constraint on the width of these sequences.
     Subbinaries and individual bits may be addressed using subscripts as described in 12.3.
     
@@ -180,7 +180,7 @@ class BINARY(str):
         return str.__new__(self, value)
         
     def __init__(self, value, width=-1, fixed=False):
-        """ By default, lenght is set to None"""
+        """ By default, length is set to None"""
         self._specified_width = width
         self._fixed = fixed
         # Check implicit width


### PR DESCRIPTION
+ Using http://www.lisi.ensma.fr/ftp/enseignement/A3_Master_Ingenierie_donnees/fonctionsGrammaire_EXPRESS.pdf typos in text files for Builtin.py were fixed.
+ other hexcodes created from conversion to text were fixed
+ human error typos fixed
