### PR TITLE
Fix build error with g++ 6.3 (Debian Stretch)

### DIFF
--- a/cmake/SC_Config_Headers.cmake
+++ b/cmake/SC_Config_Headers.cmake
@@ -80,7 +80,7 @@ std::cout << \"1s is \"<< std::chrono::duration_cast<std::chrono::milliseconds>(
   set( TEST_NULLPTR "
 #include <cstddef>
 std::nullptr_t f() {return nullptr;}
-int main() {return !!f();}
+int main() {return !(f() == f());}
   " )
   cmake_push_check_state()
   if( UNIX )


### PR DESCRIPTION
On this platform, TEST_NULLPTR fails, even though nullptr and
nullptr_t are supported:

~~~~
/home/jepler/src/stepcode/build/CMakeFiles/CMakeTmp/src.cxx:4:23:
    error: converting to 'bool' from 'std::nullptr_t'
    requires direct-initialization [-fpermissive]
 int main() {return !!f();}
                      ~^~
~~~~

Subsequent to this failure, the workaround definitions in sc_nullptr.h
prevent standard C++ headers (which must refer to real nullptr) from
compiling.

The failure occurs because the C++ standard apparently does not state
that operator! may be used on nullptr.  Despite this, some compilers
have historically allowed it.  g++ 6.3's behavior appears to be aligned
with the standard.