### PR TITLE
Fix problems detected by "-fsanitize=address"

### DIFF
--- a/src/clutils/errordesc.cc
+++ b/src/clutils/errordesc.cc
@@ -131,7 +131,7 @@ void ErrorDescriptor::PrependToUserMsg( const char * msg ) {
 }
 
 void ErrorDescriptor::AppendToUserMsg( const char c ) {
-    _userMsg.append( &c );
+    _userMsg.push_back( c );
 }
 
 void ErrorDescriptor::AppendToUserMsg( const char * msg ) {
@@ -147,7 +147,7 @@ void ErrorDescriptor::PrependToDetailMsg( const char * msg ) {
 }
 
 void ErrorDescriptor::AppendToDetailMsg( const char c ) {
-    _detailMsg.append( &c );
+    _detailMsg.push_back( c );
 }
 
 void ErrorDescriptor::AppendToDetailMsg( const char * msg ) {


### PR DESCRIPTION
It was mentioned on #357 that the appveryor build has never worked.  This made me interested in the testsuite, though of course I tested on Linux where the lighting is good.  Specifically, I used clang++ 3.8.1 on Debian Stretch in "AddressSanitizer" mode.  This mode can find many accesses-past-end-of-buffer.  These patches fix the non-leak errors encountered when building as shown:
~~~~
export ASAN_OPTIONS="detect_leaks=false"
CXX="clang++" CC=clang CXXFLAGS="-fsanitize=address" LDFLAGS="-fsanitize=address" cmake .. -DSC_ENABLE_TESTING=ON  -DSC_BUILD_SCHEMAS="ifc2x3;ap214e3;ap209"
make
ctest . --output-on-failure
~~~~

Before the change,
~~~~
79% tests passed, 42 tests failed out of 200
~~~~
though unfortunately the generate_cpp_sdai_ap214e3 test which failed on windows did not fail under AddressSanitizer, so there's no reason to think I fixed that.