### PR TITLE
Fix test parallelism failures

### DIFF
--- a/cmake/sc_version_string.cmake
+++ b/cmake/sc_version_string.cmake
@@ -8,6 +8,7 @@
 # http://www.cmake.org/pipermail/cmake/2009-February/027014.html
 
 set(SC_IS_SUBBUILD "@SC_IS_SUBBUILD@")
+set(SC_ENABLE_TESTING "@SC_ENABLE_TESTING@")
 
 set(SC_VERSION_HEADER "${BINARY_DIR}/include/sc_version_string.h")
 
@@ -47,7 +48,9 @@ string(REPLACE "\n" "" GIT_COMMIT_ID ${GIT_COMMIT_ID})
 #once cmake_minimum_required is >= 2.8.11, we can use TIMESTAMP:
 #string(TIMESTAMP date_time_string)
 
-if(UNIX)
+if(SC_ENABLE_TESTING)
+  set (date_time_string "NA - disabled for testing")
+elseif(UNIX)
   execute_process(COMMAND date "+%d %b %Y %H:%M" OUTPUT_VARIABLE date_time_string OUTPUT_STRIP_TRAILING_WHITESPACE)
 elseif(WIN32)
   execute_process(COMMAND cmd /c date /t OUTPUT_VARIABLE currentDate OUTPUT_STRIP_TRAILING_WHITESPACE)

--- a/cmake/sc_version_string.cmake
+++ b/cmake/sc_version_string.cmake
@@ -78,9 +78,10 @@ set(header_string "/* sc_version_string.h - written by cmake. Changes will be lo
  )
 
 #don't update the file unless somethig changed
-file(WRITE ${SC_VERSION_HEADER}.tmp ${header_string})
-execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different ${SC_VERSION_HEADER}.tmp ${SC_VERSION_HEADER})
-execute_process(COMMAND ${CMAKE_COMMAND} -E remove ${SC_VERSION_HEADER}.tmp)
+string(RANDOM tmpsuffix)
+file(WRITE ${SC_VERSION_HEADER}.${tmpsuffix} ${header_string})
+execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different ${SC_VERSION_HEADER}.${tmpsuffix} ${SC_VERSION_HEADER})
+execute_process(COMMAND ${CMAKE_COMMAND} -E remove ${SC_VERSION_HEADER}.${tmpsuffix})
 
 if(NOT SC_IS_SUBBUILD)
   message("-- sc_version_string.h is up-to-date.")


### PR DESCRIPTION
These two changes fix the overt and subtle problem I identified with parallel ctest.  After applying these two changes locally, I was able to complete 24 consecutive 'ctest' invocations each with a parallelism of 24 (on an 4C/8T system).  Typical end of successful test output:
~~~~
100% tests passed, 0 tests failed out of 242

Label Time Summary:
cpp_schema_build       =  76.07 sec (44 tests)
cpp_schema_gen         =  25.17 sec (22 tests)
cpp_schema_rw          =  39.02 sec (78 tests)
cpp_schema_specific    =   8.50 sec (13 tests)
cpp_unit_stepcore      =   4.68 sec (8 tests)
exchange_file          =   0.93 sec (33 tests)
parser                 =   1.03 sec (2 tests)
unitary_schemas        =   0.25 sec (31 tests)

Total Test time (real) =   8.34 sec
~~~~

Closes: #359 