### PR TITLE
appveyor build: don't use ctest parallelism

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -58,7 +58,7 @@ test_script:
   - cmd: echo Running CTest...
   - cmd: cd c:\projects\STEPcode\build
   - cmd: echo excluding test_inverse_attr3, which hangs
-  - cmd: ctest -j2 . -C Debug -E test_inverse_attr3 --output-on-failure
+  - cmd: ctest -j1 . -C Debug -E test_inverse_attr3 --output-on-failure
 
 # - cmd: grep -niB20 "Test Failed" Testing/Temporary/LastTest.log
 


### PR DESCRIPTION
On Windows, concurrent access to files is severely restricted
compared to standard operating systems.  When ctest is invoking
cmake, this causes it to write simultaneously to the same files in
each concurrent cmake invocation, leading to spurious test failures
like

  error MSB3491: Could not write lines to file "...".  The process
  cannot access the file '...' because it is being used by another
  process.

Explicitly ask for no parallelism with "-j1", even though it is
probably the default.