### PR TITLE
fix test_inverse_attr3 failures on appveyor (windows)

### DIFF
--- a/src/cllazyfile/lazyFileReader.cc
+++ b/src/cllazyfile/lazyFileReader.cc
@@ -50,7 +50,7 @@ instancesLoaded_t * lazyFileReader::getHeaderInstances() {
 }
 
 lazyFileReader::lazyFileReader( std::string fname, lazyInstMgr * i, fileID fid ): _fileName( fname ), _parent( i ), _fileID( fid ) {
-    _file.open( _fileName.c_str() );
+    _file.open( _fileName.c_str(), std::ios::binary );
     _file.imbue( std::locale::classic() );
     _file.unsetf( std::ios_base::skipws );
     assert( _file.is_open() && _file.good() );


### PR DESCRIPTION
By changing the open mode to include the "binary" bit, the behavior of an ifstream is modified on Windows, because it no longer expects "\r\n" line endings.   The file open mode can affect operations like unget, tellg, and seekg.  It also appears to fix the "test_inverse_attr3" test on appveyor.

This PR is actually cumulative with my others, in particular #362 to switch from `unget` to `seekg`,
and #361 to not use ctest parallelism on appveyor.

I don't have a full explanation of why this fixes the problem, but I believe it has something to do with Windows "text" file modes, where CRLF line endings are expected; coupled with files that actually have Unix-style line endings, and the `unget` / `seekg` method of moving around within files.  In particular, I wonder if `unget` on a Unix file can back up to an unexpected character if it backs up over a LF where it thinks there should have been a CRLF.  The `seekg(tellg() - 1)` method is certain to be standards-violating in text mode, because it is only permitted to seek to exact file positions returned by `tellg`, not ones formed by arithmetic on file positions.

Besides this hand-waving explanation, I also arranged for appveyor to run the test 100 times; it did not hang.  You can view the output of this run here: https://ci.appveyor.com/project/jepler/stepcode/build/32