### PR TITLE
Source typo

### DIFF
--- a/data/ap214e3/AP214E3_2010.exp
+++ b/data/ap214e3/AP214E3_2010.exp
@@ -4409,7 +4409,7 @@ WHERE
     item_identified_representation_usage.identified_item)) OR (
     'AUTOMOTIVE_DESIGN.' + 'DIMENSIONAL_SIZE' IN TYPEOF(SELF\
     item_identified_representation_usage.definition)) AND ((SELF\
-    item_identified_representation_usage.definition.name = 'heigth') OR (SELF\
+    item_identified_representation_usage.definition.name = 'height') OR (SELF\
     item_identified_representation_usage.definition.name = 'length') OR (SELF\
     item_identified_representation_usage.definition.name = 'width'));
   wr7 : NOT ('AUTOMOTIVE_DESIGN.' + 'RADIUS_DIMENSION' IN TYPEOF(SELF\

--- a/src/exp2python/python/SCL/SimpleDataTypes.py
+++ b/src/exp2python/python/SCL/SimpleDataTypes.py
@@ -117,7 +117,7 @@ class STRING(str):
     318 width_spec = '(' width ')' [ FIXED ] .
     317 width = numeric_expression .
     A string data type may be defined as either fixed or varying width (number of characters). If
-    it is not specfically defined as fixed width (by using the fixed reserved word in the dfinition)
+    it is not specifically defined as fixed width (by using the fixed reserved word in the definition)
     the string has varying width.
     
     The domain of a fixed width string data type is the set of all character sequences of exactly


### PR DESCRIPTION
Found via `codespell`
please review