### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/misc/wiki-scripts/update-matrix.py
+++ b/misc/wiki-scripts/update-matrix.py
@@ -5,6 +5,7 @@
 
 #must be ran from scl/build_matrix
 
+from __future__ import print_function
 from xml.etree import ElementTree as ET
 import os
 from datetime import date
@@ -49,7 +50,7 @@ def find_xml():
         if str(date.today().year) in dirname:
             i += 1
             if i > 1:
-                print "Too many directories, exiting"
+                print("Too many directories, exiting")
                 exit(1)
             xml = os.path.join("Testing", dirname, "Test.xml")
     return xml
@@ -58,31 +59,31 @@ def find_wiki():
     #find wiki and matrix file, issue 'git pull'
     wikipath = os.path.abspath("../../wiki-scl")
     if not os.path.isdir(os.path.join(wikipath,".git")):
-        print "Can't find wiki or not a git repo"
+        print("Can't find wiki or not a git repo")
         exit(1)
     p = subprocess.call(["git", "pull", "origin"], cwd=wikipath)
     if not p == 0:
-        print "'git pull' exited with error"
+        print("'git pull' exited with error")
         exit(1)
     matrix = os.path.join(wikipath, "Schema-build-matrix.md")
     if not os.path.isfile(matrix):
-        print "Matrix file doesn't exist or isn't a file"
+        print("Matrix file doesn't exist or isn't a file")
         exit(1)
     return wikipath,matrix
 
 def git_push(path,f):
     p = subprocess.call(["git", "add", f], cwd=path)
     if not p == 0:
-        print "'git add' exited with error"
+        print("'git add' exited with error")
         exit(1)
     msg = date.today().__str__() + " - schema matrix updated by update-matrix.py"
     p = subprocess.call(["git", "commit", "-m", msg ], cwd=path)
     if not p == 0:
-        print "'git commit' exited with error"
+        print("'git commit' exited with error")
         exit(1)
     p = subprocess.call(["git", "push", "origin"], cwd=path)
     if not p == 0:
-        print "'git push' exited with error"
+        print("'git push' exited with error")
         exit(1)
 
 
@@ -98,8 +99,8 @@ def read_tests(xml):
     # read all <Test>s in xml, create mixed html/markdown
     try:
         tree = ET.parse(xml)
-    except Exception, inst:
-        print "Unexpected error opening %s: %s" % (xml, inst)
+    except Exception as inst:
+        print("Unexpected error opening %s: %s" % (xml, inst))
         return
 
     root = tree.getroot()

--- a/src/exp2python/python/SCL/AggregationDataTypes.py
+++ b/src/exp2python/python/SCL/AggregationDataTypes.py
@@ -126,9 +126,9 @@ class ARRAY(BaseType.Type, BaseType.Aggregate):
     """
     def __init__( self ,  bound_1 , bound_2 , base_type , UNIQUE = False, OPTIONAL=False, scope = None):
         BaseType.Type.__init__(self, base_type, scope)
-        if not type(bound_1)==int:
+        if not isinstance(bound_1, int):
             raise TypeError("ARRAY lower bound must be an integer")
-        if not type(bound_2)==int:
+        if not isinstance(bound_2, int):
             raise TypeError("ARRAY upper bound must be an integer")
         if not (bound_1 <= bound_2):
             raise AssertionError("ARRAY lower bound must be less than or equal to upper bound")
@@ -235,17 +235,17 @@ class LIST(BaseType.Type, BaseType.Aggregate):
     """
     def __init__( self ,  bound_1 , bound_2 , base_type , UNIQUE = False, scope = None):
         BaseType.Type.__init__(self, base_type, scope)
-        if not type(bound_1)==int:
+        if not isinstance(bound_1, int):
             raise TypeError("LIST lower bound must be an integer")
         # bound_2 can be set to None
         self._unbounded = False
         if bound_2 == None:
             self._unbounded = True
-        elif not type(bound_2)==int:
+        elif not isinstance(bound_2, int):
             raise TypeError("LIST upper bound must be an integer")
         if not bound_1>=0:
             raise AssertionError("LIST lower bound must be greater of equal to 0")
-        if (type(bound_2)==int and not (bound_1 <= bound_2)):
+        if (isinstance(bound_2, int) and not (bound_1 <= bound_2)):
             raise AssertionError("ARRAY lower bound must be less than or equal to upper bound")
         # set up class attributes
         self._bound_1 = bound_1
@@ -282,14 +282,14 @@ class LIST(BaseType.Type, BaseType.Aggregate):
 
     def get_hibound(self):
         hibound = self._bound_2
-        if type(hibound)==int:
+        if isinstance(hibound, int):
             return INTEGER(hibound)
         else:
             return hibound
     
     def get_lobound(self):
         lobound = self._bound_1
-        if type(lobound)==int:
+        if isinstance(lobound, int):
             return INTEGER(lobound)
         else:
             return lobound
@@ -409,17 +409,17 @@ class BAG(BaseType.Type, BaseType.Aggregate):
     """
     def __init__( self ,  bound_1 , bound_2 , base_type , scope = None):
         BaseType.Type.__init__(self, base_type, scope)
-        if not type(bound_1)==int:
+        if not isinstance(bound_1, int):
             raise TypeError("LIST lower bound must be an integer")
         # bound_2 can be set to None
         self._unbounded = False
         if bound_2 == None:
             self._unbounded = True
-        elif not type(bound_2)==int:
+        elif not isinstance(bound_2, int):
             raise TypeError("LIST upper bound must be an integer")
         if not bound_1>=0:
             raise AssertionError("LIST lower bound must be greater of equal to 0")
-        if (type(bound_2)==int and not (bound_1 <= bound_2)):
+        if (isinstance(bound_2, int) and not (bound_1 <= bound_2)):
             raise AssertionError("ARRAY lower bound must be less than or equal to upper bound")
         # set up class attributes
         self._bound_1 = bound_1
@@ -462,14 +462,14 @@ class BAG(BaseType.Type, BaseType.Aggregate):
 
     def get_hibound(self):
         hibound = self._bound_2
-        if type(hibound)==int:
+        if isinstance(hibound, int):
             return INTEGER(hibound)
         else:
             return hibound
 
     def get_lobound(self):
         lobound = self._bound_1
-        if type(lobound)==int:
+        if isinstance(lobound, int):
             return INTEGER(lobound)
         else:
             return lobound
@@ -527,17 +527,17 @@ class SET(BaseType.Type, BaseType.Aggregate):
     """
     def __init__( self ,  bound_1 , bound_2 , base_type , scope = None):
         BaseType.Type.__init__(self, base_type, scope)
-        if not type(bound_1)==int:
+        if not isinstance(bound_1, int):
             raise TypeError("LIST lower bound must be an integer")
         # bound_2 can be set to None
         self._unbounded = False
         if bound_2 == None:
             self._unbounded = True
-        elif not type(bound_2)==int:
+        elif not isinstance(bound_2, int):
             raise TypeError("LIST upper bound must be an integer")
         if not bound_1>=0:
             raise AssertionError("LIST lower bound must be greater of equal to 0")
-        if (type(bound_2)==int and not (bound_1 <= bound_2)):
+        if (isinstance(bound_2, int) and not (bound_1 <= bound_2)):
             raise AssertionError("ARRAY lower bound must be less than or equal to upper bound")
         # set up class attributes
         self._bound_1 = bound_1
@@ -581,14 +581,14 @@ class SET(BaseType.Type, BaseType.Aggregate):
 
     def get_hibound(self):
         hibound = self._bound_2
-        if type(hibound)==int:
+        if isinstance(hibound, int):
             return INTEGER(hibound)
         else:
             return hibound
 
     def get_lobound(self):
         lobound = self._bound_1
-        if type(lobound)==int:
+        if isinstance(lobound, int):
             return INTEGER(lobound)
         else:
             return lobound

--- a/src/exp2python/python/SCL/BaseType.py
+++ b/src/exp2python/python/SCL/BaseType.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright (c) 2011, Thomas Paviot (tpaviot@gmail.com)
 # All rights reserved.
 
@@ -43,10 +44,10 @@ class Type(object):
         return self._scope
     
     def get_type(self):
-        if type(self._typedef) == str:
+        if isinstance(self._typedef, str):
             if self._scope == None:
                 raise AssertionError('No scope defined for this type')
-            elif vars(self._scope).has_key(self._typedef):
+            elif self._typedef in vars(self._scope):
                 return vars(self._scope)[self._typedef]
             else:
                 raise TypeError("Type '%s' is not defined in given scope"%self._typedef)
@@ -65,5 +66,5 @@ if __name__ == "__main__":
     class line:
         pass
     new_type = Type('lie',scp)
-    print new_type.get_type()
+    print(new_type.get_type())
     

--- a/src/exp2python/python/SCL/ConstructedDataTypes.py
+++ b/src/exp2python/python/SCL/ConstructedDataTypes.py
@@ -66,7 +66,7 @@ class SELECT(object):
     """
     def __init__(self,*kargs,**args):
         # first defining the scope
-        if args.has_key('scope'):
+        if 'scope' in args:
             self._scope = args['scope']
         else:
             self._scope = None

--- a/src/exp2python/python/SCL/Model.py
+++ b/src/exp2python/python/SCL/Model.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright (c) 2011-2012, Thomas Paviot (tpaviot@gmail.com)
 # All rights reserved.
 
@@ -33,7 +34,7 @@ class Model(objet):
     """ The container for entity instances
     """
     def __init_(self):
-        print "Model initialized"
+        print("Model initialized")
         self._instances = []
     
     def add_instance(self, entity_instance):

--- a/src/exp2python/python/SCL/SimpleDataTypes.py
+++ b/src/exp2python/python/SCL/SimpleDataTypes.py
@@ -32,6 +32,7 @@
 """
 Docstrings are courtesy of ISO 10303-11:1994(E)
 """
+from __future__ import print_function
 
 class NUMBER:
     """
@@ -198,19 +199,19 @@ class BINARY(str):
 
 
 if __name__=="__main__":
-    print "Creating REAL from float value"
+    print("Creating REAL from float value")
     a = REAL(1.5)
-    print a*2
-    print "Creating REAL from string value"
+    print(a*2)
+    print("Creating REAL from string value")
     a = REAL("1.2")
-    print a*3
-    print "Creating INTEGER from int value"
+    print(a*3)
+    print("Creating INTEGER from int value")
     b = INTEGER(2)
     c = INTEGER(3)
-    print b+c
-    print "Creating INTEGER from string value"
+    print(b+c)
+    print("Creating INTEGER from string value")
     e = INTEGER("5")
     f = INTEGER("8")
-    print e*f
+    print(e*f)
     
     

--- a/src/exp2python/python/SCL/TypeChecker.py
+++ b/src/exp2python/python/SCL/TypeChecker.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright (c) 2011, Thomas Paviot (tpaviot@gmail.com)
 # All rights reserved.
 
@@ -40,7 +41,7 @@ def cast_python_object_to_aggregate(obj, aggregate):
     [1.,2.,3.]-> ARRAY(1,3,REAL)"""
     aggregate_lower_bound = aggregate.bound_1()
     aggregate_upper_bound = aggregate.bound_2()
-    if type(obj)==list:
+    if isinstance(obj, list):
         for idx in range(aggregate_lower_bound,aggregate_upper_bound+1):
             aggregate[idx] = obj[idx-aggregate_lower_bound]
     return aggregate
@@ -51,9 +52,9 @@ def check_type(instance, expected_type):
     """
     type_match = False #by default, will be set to True if any match
     if DEBUG:
-        print "==="
-        print "Instance passed: ",instance
-        print "Expected type: ", expected_type
+        print("===")
+        print("Instance passed: ",instance)
+        print("Expected type: ", expected_type)
     # in the case of an enumeration, we have to check if the instance is in the list
     if (isinstance(expected_type,ENUMERATION)):
         allowed_ids = expected_type.get_enum_ids()
@@ -71,11 +72,11 @@ def check_type(instance, expected_type):
             if RAISE_EXCEPTION_IF_TYPE_DOES_NOT_MATCH:
                 raise TypeError('Argument type must be %s (you passed %s)'%(allowed_types,type(instance)))
             else:
-                print "WARNING: expected '%s' but passed a '%s', casting from python value to EXPRESS type"%(allowed_types, type(instance))
+                print("WARNING: expected '%s' but passed a '%s', casting from python value to EXPRESS type"%(allowed_types, type(instance)))
                 return False
     elif (isinstance(expected_type, BaseType.Aggregate)):
         # first check that they are instance of the same class
-        if not (type(instance) == type(expected_type)):
+        if not (isinstance(instance, type(expected_type))):
             raise TypeError('Expected %s but passed %s'%(type(expected_type),type(instance)))
         # then check that the base type is the same
         elif not (instance.get_type() == expected_type.get_type()):
@@ -96,6 +97,6 @@ def check_type(instance, expected_type):
             if RAISE_EXCEPTION_IF_TYPE_DOES_NOT_MATCH:
                 raise TypeError('Argument type must be %s (you passed %s)'%(expected_type,type(instance)))
             else:
-                print "WARNING: expected '%s' but passed a '%s', casting from python value to EXPRESS type"%(expected_type, type(instance))
+                print("WARNING: expected '%s' but passed a '%s', casting from python value to EXPRESS type"%(expected_type, type(instance)))
                 return False
     return True

--- a/src/exp2python/python/SCL/Utils.py
+++ b/src/exp2python/python/SCL/Utils.py
@@ -30,6 +30,7 @@
 # THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ''' This module provide string utils'''
+from __future__ import print_function
 
 def process_nested_parent_str(attr_str,idx=0):
     '''
@@ -61,10 +62,10 @@ def process_nested_parent_str(attr_str,idx=0):
     return params,k
 
 if __name__=="__main__":
-    print process_nested_parent_str2("'A'")[0]
-    print process_nested_parent_str2("30.0,0.0,5.0")[0]
-    print process_nested_parent_str2("1,2,(3,4,5),6,7,8")[0]
-    print process_nested_parent_str2("(#9149,#9166),#9142,.T.")[0]
+    print(process_nested_parent_str2("'A'")[0])
+    print(process_nested_parent_str2("30.0,0.0,5.0")[0])
+    print(process_nested_parent_str2("1,2,(3,4,5),6,7,8")[0])
+    print(process_nested_parent_str2("(#9149,#9166),#9142,.T.")[0])
 
 
 

--- a/src/exp2python/python/SCL/essa_par.py
+++ b/src/exp2python/python/SCL/essa_par.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 def process_nested_parent_str(attr_str):
     '''
     The first letter should be a parenthesis
@@ -63,9 +64,9 @@ def process_nested_parent_str2(attr_str,idx=0):
 #print process_nested_parent_str2('1,2,3,4,5,6')
 #idx=0
 #print process_nested_parent_str2("'A','B','C'")
-print process_nested_parent_str2("'A'")[0]
-print process_nested_parent_str2("30.0,0.0,5.0")[0]
-print process_nested_parent_str2("(Thomas)")[0]
-print process_nested_parent_str2("Thomas, Paviot, ouais")[0]
-print process_nested_parent_str2("1,2,(3,4,5),6,7,8")[0]
-print process_nested_parent_str2("(#9149,#9166),#9142,.T.")[0]
+print(process_nested_parent_str2("'A'")[0])
+print(process_nested_parent_str2("30.0,0.0,5.0")[0])
+print(process_nested_parent_str2("(Thomas)")[0])
+print(process_nested_parent_str2("Thomas, Paviot, ouais")[0])
+print(process_nested_parent_str2("1,2,(3,4,5),6,7,8")[0])
+print(process_nested_parent_str2("(#9149,#9166),#9142,.T.")[0])

--- a/src/exp2python/test/test_base.py
+++ b/src/exp2python/test/test_base.py
@@ -58,7 +58,7 @@ class TestINTEGER(unittest.TestCase):
     
     def test_type(self):
         a = INTEGER(5)
-        self.assertTrue(type(a) == INTEGER)
+        self.assertTrue(isinstance(a, INTEGER))
     
     def test_inherit_from_NUMBER(self):
         a = INTEGER(6)
@@ -70,7 +70,7 @@ class TestINTEGER(unittest.TestCase):
         b = INTEGER(3)
         c = a*b
         self.assertEqual(c,6)
-        self.assertTrue(type(c) == int)
+        self.assertTrue(isinstance(c, int))
     
     def test_create_from_string_exception(self):
         '''
@@ -103,7 +103,7 @@ class TestREAL(unittest.TestCase):
     
     def test_type(self):
         a = REAL(5)
-        self.assertTrue(type(a) == REAL)
+        self.assertTrue(isinstance(a, REAL))
     
     def test_inherit_from_NUMBER(self):
         a = REAL(4.5)
@@ -115,13 +115,13 @@ class TestREAL(unittest.TestCase):
         b = REAL(2)
         c = a*b
         self.assertEqual(c,3)
-        self.assertTrue(type(c) == float)
+        self.assertTrue(isinstance(c, float))
     
     def test_REAL_INTEGER_ops(self):
         a = REAL(5.5)
         b = INTEGER(3)
         self.assertEqual(a+b,8.5)
-        self.assertTrue(type(a+b) == float)
+        self.assertTrue(isinstance(a+b, float))
         
     def test_create_from_string_exception(self):
         '''


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.

Also changed direct comparison of types to __isinstance()__ as recommended in PEP8.

[flake8](http://flake8.pycqa.org) testing of https://github.com/stepcode/stepcode on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./src/exp2python/python/SCL/Model.py:36:33: E999 SyntaxError: invalid syntax
        print "Model initialized"
                                ^
./src/exp2python/python/SCL/TypeChecker.py:54:19: E999 SyntaxError: invalid syntax
        print "==="
                  ^
./src/exp2python/python/SCL/SimpleDataTypes.py:201:42: E999 SyntaxError: invalid syntax
    print "Creating REAL from float value"
                                         ^
./src/exp2python/python/SCL/essa_par.py:66:32: E999 SyntaxError: invalid syntax
print process_nested_parent_str2("'A'")[0]
                               ^
./src/exp2python/python/SCL/BaseType.py:68:18: E999 SyntaxError: invalid syntax
    print new_type.get_type()
                 ^
./src/exp2python/python/SCL/Utils.py:64:36: E999 SyntaxError: invalid syntax
    print process_nested_parent_str2("'A'")[0]
                                   ^
./misc/wiki-scripts/update-matrix.py:52:53: E999 SyntaxError: invalid syntax
                print "Too many directories, exiting"
                                                    ^
7     E999 SyntaxError: invalid syntax
7
```

__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree
