### PR TITLE
Fix all 'Testing equality to None' issues

### DIFF
--- a/src/exp2python/python/SCL/AggregationDataTypes.py
+++ b/src/exp2python/python/SCL/AggregationDataTypes.py
@@ -179,7 +179,7 @@ class ARRAY(BaseType.Type, BaseType.Aggregate):
             raise IndexError("ARRAY index out of bound (upper bound is %i, passed %i)"%(self._bound_2,index))
         else:
             value = self._container[index-self._bound_1]
-            if not self._optional and value==None:
+            if not self._optional and value is None:
                 raise AssertionError("Not OPTIONAL prevent the value with index %i from being None (default). Please set the value first."%index)
             return value
  
@@ -239,7 +239,7 @@ class LIST(BaseType.Type, BaseType.Aggregate):
             raise TypeError("LIST lower bound must be an integer")
         # bound_2 can be set to None
         self._unbounded = False
-        if bound_2 == None:
+        if bound_2 is None:
             self._unbounded = True
         elif not isinstance(bound_2, int):
             raise TypeError("LIST upper bound must be an integer")
@@ -313,7 +313,7 @@ class LIST(BaseType.Type, BaseType.Aggregate):
                 raise IndexError("ARRAY index out of bound (upper bound is %i, passed %i)"%(self._bound_2,index))
             else:
                 value = self._container[index-self._bound_1]
-                if value == None:
+                if value is None:
                     raise AssertionError("Value with index %i not defined. Please set the value first."%index)
                 return value
         #case unbounded
@@ -322,7 +322,7 @@ class LIST(BaseType.Type, BaseType.Aggregate):
                 raise AssertionError("Value with index %i not defined. Please set the value first."%index)
             else:
                 value = self._container[index-self._bound_1]
-                if value == None:
+                if value is None:
                     raise AssertionError("Value with index %i not defined. Please set the value first."%index)
                 return value
  
@@ -413,7 +413,7 @@ class BAG(BaseType.Type, BaseType.Aggregate):
             raise TypeError("LIST lower bound must be an integer")
         # bound_2 can be set to None
         self._unbounded = False
-        if bound_2 == None:
+        if bound_2 is None:
             self._unbounded = True
         elif not isinstance(bound_2, int):
             raise TypeError("LIST upper bound must be an integer")
@@ -531,7 +531,7 @@ class SET(BaseType.Type, BaseType.Aggregate):
             raise TypeError("LIST lower bound must be an integer")
         # bound_2 can be set to None
         self._unbounded = False
-        if bound_2 == None:
+        if bound_2 is None:
             self._unbounded = True
         elif not isinstance(bound_2, int):
             raise TypeError("LIST upper bound must be an integer")

--- a/src/exp2python/python/SCL/BaseType.py
+++ b/src/exp2python/python/SCL/BaseType.py
@@ -45,7 +45,7 @@ class Type(object):
     
     def get_type(self):
         if isinstance(self._typedef, str):
-            if self._scope == None:
+            if self._scope is None:
                 raise AssertionError('No scope defined for this type')
             elif self._typedef in vars(self._scope):
                 return vars(self._scope)[self._typedef]

--- a/src/exp2python/python/SCL/Builtin.py
+++ b/src/exp2python/python/SCL/Builtin.py
@@ -220,7 +220,7 @@ def SIN(V):
 #Result : true or false depending on whether V has an actual or indeterminate (?) value.
 #EXAMPLE 131 { IF EXISTS ( a ) THEN ...
 def EXISTS(V):
-    if V==None:
+    if V is None:
         return False
     else:
         return True


### PR DESCRIPTION
Testing whether an object is `None` using the `==` operator is inefficient and potentially incorrect. This PR has substituted all instances (that are not subject to be regenerated by exp2python) with`is None`