### PR TITLE
Define a default copy constructor.

### DIFF
--- a/src/exp2cxx/classes_type.c
+++ b/src/exp2cxx/classes_type.c
@@ -182,12 +182,12 @@ void TYPEenum_inc_print( const Type type, FILE * inc ) {
 
     /*  constructors    */
     strncpy( tdnm, TYPEtd_name( type ), BUFSIZ );
-    tdnm[BUFSIZ-1] = '\0';
-    fprintf( inc, "  public:\n        %s (const char * n =0, Enum"
-             "TypeDescriptor *et =%s);\n", n, tdnm );
+    tdnm[BUFSIZ - 1] = '\0';
+    fprintf( inc, "  public:\n        %s (const char * n =0, EnumTypeDescriptor *et =%s);\n", n, tdnm );
     fprintf( inc, "        %s (%s e, EnumTypeDescriptor *et =%s)\n"
              "                : type(et) {  set_value (e);  }\n",
              n, EnumName( TYPEget_name( type ) ), tdnm );
+    fprintf( inc, "        %s (const %s &e) { set_value(e); }\n", n, TYPEget_ctype( type ) );
 
     /*  destructor  */
     fprintf( inc, "        ~%s () { }\n", n );


### PR DESCRIPTION
Werror=deprecated-copy with GCC was triggered by code generated from
this exp2cxx output.  Go ahead and define the copy constructor to
avoid the deprecated behavior.