### PR TITLE
Remove Raw() and getEDesc(), restore C asStr()

### DIFF
--- a/src/cllazyfile/lazyRefs.h
+++ b/src/cllazyfile/lazyRefs.h
@@ -115,9 +115,9 @@ class SC_LAZYFILE_EXPORT lazyRefs {
                     if( !ai ) {
                         ias.i = rinst;
                         _inst->setInvAttr( ia, ias );
-                    } else if( ai->GetFileId() != (int)inst ) {
-                        std::cerr << "ERROR: two instances (" << rinst << ", #" << rinst->GetFileId() << "=" << rinst->getEDesc()->Name();
-                        std::cerr << " and " << ai << ", #" << ai->GetFileId() <<"=" << ai->getEDesc()->Name() << ") refer to inst ";
+                    } else if( ai->GetFileId() != ( int )inst ) {
+                        std::cerr << "ERROR: two instances (" << rinst << ", #" << rinst->GetFileId() << "=" << rinst->eDesc->Name();
+                        std::cerr << " and " << ai << ", #" << ai->GetFileId() << "=" << ai->eDesc->Name() << ") refer to inst ";
                         std::cerr << _inst->GetFileId() << ", but its inverse attribute is not an aggregation type!" << std::endl;
                         // TODO _error->GreaterSeverity( SEVERITY_INPUT_ERROR );
                     }
@@ -184,7 +184,7 @@ class SC_LAZYFILE_EXPORT lazyRefs {
                 }
                 ++iai;
             }
-            std::cerr << "Error! inverse attr " << ia->Name() << " (" << ia << ") not found in iAMap for entity " << inst->getEDesc()->Name() << std::endl;
+            std::cerr << "Error! inverse attr " << ia->Name() << " (" << ia << ") not found in iAMap for entity " << inst->eDesc->Name() << std::endl;
             abort();
             iAstruct nil = {nullptr};
             return nil;
@@ -279,7 +279,7 @@ class SC_LAZYFILE_EXPORT lazyRefs {
 
 
             // 1. find inverse attrs with recursion
-            getInverseAttrs( ai->getEDesc(), _iaList );
+            getInverseAttrs( ai->eDesc, _iaList );
 
             //2. find reverse refs, map id to type (stop if there are no inverse attrs or no refs)
             if( _iaList.size() == 0 || !mapRefsToTypes() ) {

--- a/src/cllazyfile/lazy_test.cc
+++ b/src/cllazyfile/lazy_test.cc
@@ -111,14 +111,14 @@ void dumpComplexInst( STEPcomplex * c ) {
         STEPcomplex * complex = c->head;
         while( complex ) {
             if( complex->IsComplex() ) {
-                std::cout << "Complex component " << complex->getEDesc()->Name() << " at depth " << depth << " with attr list size ";
+                std::cout << "Complex component " << complex->eDesc->Name() << " at depth " << depth << " with attr list size ";
                 std::cout << complex->_attr_data_list.size() << std::endl;
 //                 dumpComplexInst( complex, depth + 1 );
             } else {
                 //probably won't ever get here...
                 SDAI_Application_instance * ai = dynamic_cast< SDAI_Application_instance * >( complex );
                 if( ai ) {
-                    std::cout << "non-complex component at depth " << depth << ", " << ai->getEDesc()->Name() << std::endl;
+                    std::cout << "non-complex component at depth " << depth << ", " << ai->eDesc->Name() << std::endl;
                 } else {
                     std::cout << "unknown component at depth " << depth << ": " << complex << std::endl;
                 }

--- a/src/cllazyfile/sectionReader.cc
+++ b/src/cllazyfile/sectionReader.cc
@@ -306,7 +306,7 @@ SDAI_Application_instance * sectionReader::getRealInstance( const Registry * reg
         if( !comment.empty() ) {
             inst->AddP21Comment( comment );
         }
-        assert( inst->getEDesc() );
+        assert( inst->eDesc );
         _file.seekg( begin );
         findNormalString( "(" );
         _file.seekg( _file.tellg() - std::streampos(1) );

--- a/src/clstepcore/Registry.cc
+++ b/src/clstepcore/Registry.cc
@@ -260,7 +260,7 @@ SDAI_Application_instance * Registry::ObjCreate( const char * nm, const char * s
             se->Error().severity( SEVERITY_WARNING );
             se->Error().UserMsg( "ENTITY requires external mapping" );
         }
-        se->setEDesc( entd );
+        se->eDesc = entd;
         return se;
     } else {
         return ENTITY_NULL;

--- a/src/clstepcore/STEPattribute.h
+++ b/src/clstepcore/STEPattribute.h
@@ -75,21 +75,15 @@ extern SC_CORE_EXPORT void PushPastAggr1Dim( istream & in, std::string & s, Erro
 class SC_CORE_EXPORT STEPattribute {
         friend ostream & operator<< ( ostream &, STEPattribute & );
         friend class SDAI_Application_instance;
-    protected:
-        bool _derive;
-        bool _mustDeletePtr; ///if a member uses new to create an object in ptr
-        ErrorDescriptor _error;
-        STEPattribute * _redefAttr;
-        const AttrDescriptor * aDesc;
-        int refCount;
 
+    public:
         /** \union ptr
-        ** You know which of these to use based on the return value of
-        ** NonRefType() - see below. BASE_TYPE is defined in baseType.h
-        ** This variable points to an appropriate member variable in the entity
-        ** class in the generated schema class library (the entity class is
-        ** inherited from SDAI_Application_instance)
-        */
+            ** You know which of these to use based on the return value of
+            ** NonRefType() - see below. BASE_TYPE is defined in baseType.h
+            ** This variable points to an appropriate member variable in the entity
+            ** class in the generated schema class library (the entity class is
+            ** inherited from SDAI_Application_instance)
+            */
         union attrUnion {
             SDAI_String * S;                 // STRING_TYPE
             SDAI_Integer * i;                // INTEGER_TYPE (Integer is a long int)
@@ -102,6 +96,18 @@ class SC_CORE_EXPORT STEPattribute {
             SCLundefined * u;                // UNKNOWN_TYPE
             void * p;
         } ptr;
+
+
+    protected:
+        bool _derive;
+        bool _mustDeletePtr; ///if a member uses new to create an object in ptr
+        ErrorDescriptor _error;
+        STEPattribute * _redefAttr;
+    public:
+        const AttrDescriptor * aDesc;
+
+    protected:
+        int refCount;
 
         char SkipBadAttr( istream & in, char * StopChars );
         void AddErrorInfo();
@@ -137,6 +143,7 @@ class SC_CORE_EXPORT STEPattribute {
 
         /// return the attr value as a string
         string asStr( const char * currSch = 0 ) const;
+        const char * asStr( std::string &, const char * = 0 ) const;
 
         /// put the attr value in ostream
         void STEPwrite( ostream & out = cout, const char * currSch = 0 );
@@ -166,11 +173,6 @@ class SC_CORE_EXPORT STEPattribute {
         SDAI_Select               * Select();
         SCLundefined              * Undefined();
         ///@}
-
-        /// allows direct access to the union containing attr data (dangerous!)
-        attrUnion * Raw() {
-            return & ptr;
-        }
 
         /**
          * These functions allow setting the attribute value.

--- a/src/clstepcore/sdaiApplication_instance.cc
+++ b/src/clstepcore/sdaiApplication_instance.cc
@@ -170,10 +170,6 @@ void SDAI_Application_instance::AppendMultInstance( SDAI_Application_instance * 
     }
 }
 
-const EntityDescriptor* SDAI_Application_instance::getEDesc() const {
-    return eDesc;
-}
-
 // BUG implement this -- FIXME function is never used
 SDAI_Application_instance * SDAI_Application_instance::GetMiEntity( char * entName ) {
     std::string s1, s2;
@@ -788,9 +784,9 @@ Severity EntityValidLevel( SDAI_Application_instance * se,
     // DAVE: Can an entity be used in an Express TYPE so that this
     // EntityDescriptor would have type REFERENCE_TYPE -- it looks like NO
 
-    else if( se->getEDesc() ) {
+    else if( se->eDesc ) {
         // is se a descendant of ed?
-        if( se->getEDesc()->IsA( ed ) ) {
+        if( se->eDesc->IsA( ed ) ) {
             return SEVERITY_NULL;
         } else {
             if( se->IsComplex() ) {

--- a/src/clstepcore/sdaiApplication_instance.h
+++ b/src/clstepcore/sdaiApplication_instance.h
@@ -36,8 +36,8 @@ class SC_CORE_EXPORT SDAI_Application_instance  : public SDAI_DAObject_SDAI  {
 
     public:
         typedef std::map< const Inverse_attribute * const, iAstruct> iAMap_t;
-    protected:
         const EntityDescriptor * eDesc;
+    protected:
 #ifdef _MSC_VER
 #pragma warning( push )
 #pragma warning( disable: 4251 )
@@ -89,10 +89,6 @@ class SC_CORE_EXPORT SDAI_Application_instance  : public SDAI_DAObject_SDAI  {
         /// initialize inverse attribute list
         void InitIAttrs();
 
-        void setEDesc( const EntityDescriptor * const ed ) {
-            eDesc = ed;
-        }
-        const EntityDescriptor * getEDesc() const;
         void StepFileId( int fid ) {
             STEPfile_id = fid;
         }

--- a/src/exp2cxx/selects.c
+++ b/src/exp2cxx/selects.c
@@ -1493,7 +1493,7 @@ void TYPEselect_lib_part21( const Type type, FILE * f ) {
                      "        _%s = ReadEntityRef(in, &_error, \",)\", instances, addFileId);\n", dm );
             fprintf( f,
                      "        if( _%s && ( _%s != S_ENTITY_NULL) &&\n "
-                     "              ( CurrentUnderlyingType()->CanBe( _%s->getEDesc() ) ) ) {\n"
+                     "              ( CurrentUnderlyingType()->CanBe( _%s->eDesc ) ) ) {\n"
                      "            return severity();\n", dm, dm, dm );
             fprintf( f,
                      "        } else {\n "
@@ -1680,7 +1680,7 @@ void SELlib_print_protected( const Type type,  FILE * f ) {
     if( TYPEis_select( t ) ) {
         fprintf( f,
                  "    //  %s\n"  /*  item name  */
-                 "    if( %s->CanBe( se->getEDesc() ) ) {\n"
+                 "    if( %s->CanBe( se->eDesc ) ) {\n"
                  "        _%s.AssignEntity (se);\n"  /* underlying data member */
                  "        return SetUnderlyingType (%s);\n"  /* td */
                  "    }\n",

--- a/test/cpp/schema_specific/inverse_attr1.cc
+++ b/test/cpp/schema_specific/inverse_attr1.cc
@@ -43,7 +43,7 @@ bool findInverseAttrs1( InverseAItr iai, InstMgr & instList ) {
                 EntityNode * en = ( EntityNode * ) relObj->GetHead();
                 SdaiObject * obj = ( SdaiObject * ) en->node;
                 cout << "file id " << obj->StepFileId() << "; name "
-                     << instList.GetApplication_instance( obj->StepFileId() - 1 )->getEDesc()->Name() << endl;
+                     << instList.GetApplication_instance( obj->StepFileId() - 1 )->eDesc->Name() << endl;
             }
             ent_id = i;
         }


### PR DESCRIPTION
This commit removes the Raw and getEDesc methods in favor of the
simplicity of just making ptr and eDesc public.

Add back in previous version of asStr() that returns a C string.

aDesc is also made public.

These changes are motivated by BRL-CAD's use of stepcode.