### PR TITLE
Clear deprecated-copy warning from C++ class.

### DIFF
--- a/src/cldai/sdaiEnum.cc
+++ b/src/cldai/sdaiEnum.cc
@@ -313,6 +313,11 @@ SDAI_BOOLEAN & SDAI_BOOLEAN::operator= ( const SDAI_LOGICAL & t ) {
     return *this;
 }
 
+SDAI_BOOLEAN & SDAI_BOOLEAN::operator= ( const SDAI_BOOLEAN & t ) {
+    v = t;
+    return *this;
+}
+
 SDAI_BOOLEAN & SDAI_BOOLEAN::operator= ( const  Boolean t ) {
     v = t;
     return *this;

--- a/src/cldai/sdaiEnum.h
+++ b/src/cldai/sdaiEnum.h
@@ -138,6 +138,7 @@ class SC_DAI_EXPORT SDAI_BOOLEAN :
 
         operator ::Boolean() const;
         SDAI_BOOLEAN & operator=( const SDAI_LOGICAL & t );
+        SDAI_BOOLEAN & operator=( const SDAI_BOOLEAN & t );
 
         SDAI_BOOLEAN & operator=( const ::Boolean t );
         SDAI_LOGICAL operator==( const SDAI_LOGICAL & t ) const;


### PR DESCRIPTION
Getting a -Wdeprecated-copy trigger from ap210e3's use of
SDAI_BOOLEAN - make an explicit assignment operator.