### PR TITLE
Remove unneeded indentation in generated output.

### DIFF
--- a/src/exp2cxx/selects.c
+++ b/src/exp2cxx/selects.c
@@ -34,7 +34,7 @@ extern int multiple_inheritance;
                   ((t)->u.type->body->type == integer_) || \
                   ((t)->u.type->body->type == number_) )
 #define PRINT_BUG_REPORT  \
-     fprintf( f, "    std::cerr << __FILE__ << \":\" << __LINE__ <<  \":  ERROR" \
+     fprintf( f, "std::cerr << __FILE__ << \":\" << __LINE__ <<  \":  ERROR" \
               " in schema library:  \\n\" \n    << _POC_ << \"\\n\\n\";\n");
 
 #define PRINT_SELECTBUG_WARNING(f) \


### PR DESCRIPTION
Newer GCC doesn't like the indenting of this line, since in some
situations it looks as if the logic is being guarded by an if clause
when it is not.