### PR TITLE
Fix FileExists() logic

### DIFF
--- a/src/clutils/dirobj.h
+++ b/src/clutils/dirobj.h
@@ -61,10 +61,10 @@ class SC_UTILS_EXPORT DirObj {
         const char * File( int index );
         // check for file in the currently loaded directory
         bool FileExists( const char * file ) {
-            return Index( file ) ? 1 : 0;
+            return Index( file ) != -1;
         }
         bool FileExists( const std::string & file ) {
-            return Index( file.c_str() ) ? true : false;
+            return Index( file.c_str() ) != -1;
         }
         int Count();
 


### PR DESCRIPTION
`Index()` returns `-1` when it can't find the file.