### PR TITLE
Fix git clone lines to use https

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -183,9 +183,9 @@ jobs:
 
       - name: Checkout
         run: |
-          git clone --depth 1 git://github.com/BRL-CAD/brlcad.git -b main
+          git clone --depth 1 https://github.com/BRL-CAD/brlcad.git -b main
           cd brlcad/src/other/ext && rm -rf stepcode
-          git clone --depth 1 git://github.com/stepcode/stepcode.git -b develop
+          git clone --depth 1 https://github.com/stepcode/stepcode.git -b develop
           # Ordinarily BRL-CAD keeps track of what files are supposed to be
           # present in the repository.  In this case we're not interested in
           # updating the list to the working stepcode filelist, so use an empty
@@ -240,10 +240,10 @@ jobs:
 
       - name: Checkout
         run: |
-          git clone --depth 1 git://github.com/BRL-CAD/brlcad.git -b main
+          git clone --depth 1 https://github.com/BRL-CAD/brlcad.git -b main
           cd brlcad/src/other/ext
           cmake -E rm -r stepcode
-          git clone --depth 1 git://github.com/stepcode/stepcode.git -b develop
+          git clone --depth 1 https://github.com/stepcode/stepcode.git -b develop
           # Ordinarily BRL-CAD keeps track of what files are supposed to be
           # present in the repository.  In this case we're not interested in
           # updating the list to the working stepcode filelist, so use an empty


### PR DESCRIPTION
Github has disabled git:// protocol support, so we need to switch:
https://github.blog/2021-09-01-improving-git-protocol-security-github/