### PR TITLE
Change Python SCL setup.cfg name to support publication to pypi

### DIFF
--- a/src/exp2python/python/setup.cfg
+++ b/src/exp2python/python/setup.cfg
@@ -1,8 +1,8 @@
 [metadata]
-name = SCL
+name = stepcode-scl
 version = 0.6.1
 author = Thomas Paviot <tpaviot@gmail.com>, Christopher HORLER (cshorler@googlemail.com), Devon Sparks (devonsparks.com)
-description = SCL is a Python3-based library for parsing and manipulating ISO 10303 Part 21 ("STEP") files. 
+description = stepcode-scl is a Python3-based library for parsing and manipulating ISO 10303 Part 21 ("STEP") files. 
 long_description = file: README.md
 long_description_content_type = text/markdown
 


### PR DESCRIPTION
The current setup.cfg package name, SCL, is too similar to existing package names in the pypi repository, so pypi will not allow it to be committed. This change does not affect internal package name, which remains "SCL", just the name used to fetch the package from the pypi repository.

After this change is committed and posted to pypi, users will be able to fetch the package with `pip install stepcode-scl`.

I've been using SCL with good success. Publication to pypi will improve my workflow. 