### PR TITLE
Make expparse explicitly depend on scanner header

### DIFF
--- a/src/express/CMakeLists.txt
+++ b/src/express/CMakeLists.txt
@@ -18,6 +18,7 @@ if(SC_GENERATE_LP_SOURCES)
 
   add_library(objlib_expparse_c OBJECT ${LEMON_ExpParser_OUTPUTS})
   set_property(TARGET objlib_expparse_c PROPERTY POSITION_INDEPENDENT_CODE ON)
+  set_source_files_properties(${LEMON_ExpParser_OUTPUTS} PROPERTIES OBJECT_DEPENDS "${PERPLEX_ExpScanner_HDR}")
 
 else(SC_GENERATE_LP_SOURCES)
   add_subdirectory(generated)


### PR DESCRIPTION
Without this dependency, we get intermittent failures where parallel builds attempt the expparse.c compile before the necessary header is in place.