### PR TITLE
stepcore: serialize redefined attributes before derived markers

### DIFF
--- a/cmake/SC_Targets.cmake
+++ b/cmake/SC_Targets.cmake
@@ -22,6 +22,9 @@ macro(SC_ADDEXEC execname)
                 message(SEND_ERROR "SC_ADDEXEC usage error - expected STATIC LINK_LIBRARIES targets (${_lib})")
             endif()
         endif()
+        # Executables consume their dependencies but do not publish an
+        # interface to downstream targets.
+        target_link_libraries(${execname} PRIVATE ${_lib})
     endforeach()
     target_link_libraries(${execname} PRIVATE ${${_arg_prefix}_LINK_LIBRARIES})
   endif()
@@ -74,6 +77,11 @@ macro(SC_ADDLIB _addlib_target)
             message(SEND_ERROR "SC_ADDLIB usage error - expected (static) LINK_LIBRARIES targets (${_lib})")
             endif()
         endif()
+        # Schema libraries are consumed directly by generated test programs.
+        # Publish their link requirements explicitly; the legacy unscoped
+        # signature does not reliably provide a transitive interface with
+        # current CMake versions.
+        target_link_libraries(${_addlib_target} PUBLIC ${_lib})
     endforeach()
     target_link_libraries(${_addlib_target} ${_lib})
   endif()
@@ -93,4 +101,3 @@ endmacro()
 # indent-tabs-mode: t
 # End:
 # ex: shiftwidth=2 tabstop=8
-

--- a/src/clstepcore/STEPattribute.cc
+++ b/src/clstepcore/STEPattribute.cc
@@ -392,16 +392,17 @@ const char * STEPattribute::asStr( std::string & str, const char * currSch ) con
 
     str.clear();
 
+    // The attribute has been redefined by the attribute pointed
+    // to by _redefAttr so write the narrowed value in the inherited
+    // physical-file slot.  STEPread and StrToVal use this same precedence.
+    if( _redefAttr )  {
+        return _redefAttr->asStr( str, currSch );
+    }
+
     // The attribute has been derived by a subtype's attribute
     if( IsDerived() )  {
         str = "*";
         return const_cast<char *>( str.c_str() );
-    }
-
-    // The attribute has been redefined by the attribute pointed
-    // to by _redefAttr so write the redefined value.
-    if( _redefAttr )  {
-        return _redefAttr->asStr( str, currSch );
     }
 
     if( is_null() )  {
@@ -485,16 +486,17 @@ std::string STEPattribute::asStr( const char * currSch ) const {
     ostringstream ss;
     std::string str;
 
+    // The attribute has been redefined by the attribute pointed
+    // to by _redefAttr so write the narrowed value in the inherited
+    // physical-file slot.  STEPread and StrToVal use this same precedence.
+    if( _redefAttr )  {
+        return _redefAttr->asStr( currSch );
+    }
+
     // The attribute has been derived by a subtype's attribute
     if( IsDerived() )  {
         str = "*";
         return str;
-    }
-
-    // The attribute has been redefined by the attribute pointed
-    // to by _redefAttr so write the redefined value.
-    if( _redefAttr )  {
-        return _redefAttr->asStr( currSch );
     }
 
     if( is_null() )  {
@@ -587,15 +589,16 @@ void STEPattribute::STEPwriteError( ostream & out, unsigned int line, const char
  *
  */
 void STEPattribute::STEPwrite( ostream & out, const char * currSch ) {
+    // The attribute has been redefined by the attribute pointed
+    // to by _redefAttr so write the narrowed value in the inherited
+    // physical-file slot.  STEPread and StrToVal use this same precedence.
+    if( _redefAttr )  {
+        _redefAttr->STEPwrite( out, currSch );
+        return;
+    }
     // The attribute has been derived by a subtype's attribute
     if( IsDerived() ) {
         out << "*";
-        return;
-    }
-    // The attribute has been redefined by the attribute pointed
-    // to by _redefAttr so write the redefined value.
-    if( _redefAttr )  {
-        _redefAttr->STEPwrite( out );
         return;
     }
 

--- a/src/clstepcore/sdaiApplication_instance.cc
+++ b/src/clstepcore/sdaiApplication_instance.cc
@@ -565,9 +565,6 @@ Severity SDAI_Application_instance::STEPread( int id,  int idIncr,
                 if( c == ')' ) { // assume you are at the end so read last char
                     in >> c;
                 }
-                cout << "Entity #" << STEPfile_id
-                     << " skipping redefined attribute "
-                     << attributes[i].aDesc->Name() << endl << endl << flush;
             }
             // increment counter to read following attr since these attrs
             // aren't written or read => there won't be a delimiter either

--- a/src/clstepcore/test/test_operators_STEPattribute.cc
+++ b/src/clstepcore/test/test_operators_STEPattribute.cc
@@ -39,6 +39,35 @@ bool testEqu( const STEPattribute & a1, const STEPattribute & a2, bool invert, c
     return pass;
 }
 
+bool testRedefinedDerivedWrite( const AttrDescriptor & ad ) {
+    SDAI_Integer inherited_value = 123L;
+    SDAI_Integer narrowed_value = 456L;
+    STEPattribute inherited( ad, & inherited_value );
+    STEPattribute narrowed( ad, & narrowed_value );
+
+    // A redeclared explicit attribute occupies its inherited physical-file
+    // slot, which is also marked derived in the generated supertype class.
+    inherited.Derive();
+    inherited.RedefiningAttr( & narrowed );
+
+    bool pass = true;
+    std::string value;
+    inherited.asStr( value );
+    if( inherited.asStr() != "456" || value != "456" ) {
+        std::cerr << "redefined derived attribute asStr() failed" << std::endl;
+        pass = false;
+    }
+
+    std::ostringstream output;
+    inherited.STEPwrite( output );
+    if( output.str() != "456" ) {
+        std::cerr << "redefined derived attribute STEPwrite() failed" << std::endl;
+        pass = false;
+    }
+
+    return pass;
+}
+
 int main( int /*argc*/, char ** /*argv*/ ) {
     bool pass = true;
     EntityDescriptor ed( "ename", 0, LFalse, LFalse );
@@ -64,6 +93,7 @@ int main( int /*argc*/, char ** /*argv*/ ) {
 
     STEPattribute aii( adi, & s2int );
     pass &= testEqu( ai, aii, true, "ints !=" );
+    pass &= testRedefinedDerivedWrite( adi );
 
     if( pass ) {
         exit( EXIT_SUCCESS );


### PR DESCRIPTION
A redefined attribute supplies the inherited physical-file slot even when that original attribute is derived. Prefer the redefinition consistently during formatting and STEP writing, remove debug output, and cover the behavior with unit tests.